### PR TITLE
🔀 :: 박람회 삭제

### DIFF
--- a/src/main/java/team/startup/expo/domain/expo/presentation/ExpoController.java
+++ b/src/main/java/team/startup/expo/domain/expo/presentation/ExpoController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team.startup.expo.domain.expo.presentation.dto.request.GenerateExpoRequestDto;
 import team.startup.expo.domain.expo.presentation.dto.request.UpdateExpoRequestDto;
+import team.startup.expo.domain.expo.service.DeleteExpoService;
 import team.startup.expo.domain.expo.service.GenerateExpoService;
 import team.startup.expo.domain.expo.service.UpdateExpoService;
 
@@ -16,6 +17,7 @@ public class ExpoController {
 
     private final GenerateExpoService generateExpoService;
     private final UpdateExpoService updateExpoService;
+    private final DeleteExpoService deleteExpoService;
 
     @PostMapping
     public ResponseEntity<Void> generateExpo(@RequestBody GenerateExpoRequestDto dto) {
@@ -26,6 +28,12 @@ public class ExpoController {
     @PatchMapping("/{expo_id}")
     public ResponseEntity<Void> updateExpo(@PathVariable("expo_id") Long expoId, @RequestBody UpdateExpoRequestDto dto) {
         updateExpoService.execute(expoId, dto);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @DeleteMapping("/{expo_id}")
+    public ResponseEntity<Void> deleteExpo(@PathVariable("expo_id") Long expoId) {
+        deleteExpoService.execute(expoId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/team/startup/expo/domain/expo/service/DeleteExpoService.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/DeleteExpoService.java
@@ -1,0 +1,5 @@
+package team.startup.expo.domain.expo.service;
+
+public interface DeleteExpoService {
+    void execute(Long expoId);
+}

--- a/src/main/java/team/startup/expo/domain/expo/service/impl/DeleteExpoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/impl/DeleteExpoServiceImpl.java
@@ -1,0 +1,44 @@
+package team.startup.expo.domain.expo.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import team.startup.expo.domain.admin.Admin;
+import team.startup.expo.domain.admin.util.UserUtil;
+import team.startup.expo.domain.expo.Expo;
+import team.startup.expo.domain.expo.exception.NotFoundExpoException;
+import team.startup.expo.domain.expo.exception.NotMatchAdminException;
+import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.expo.service.DeleteExpoService;
+import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.standard.repository.StandardProgramRepository;
+import team.startup.expo.domain.trainee.repository.TraineeRepository;
+import team.startup.expo.domain.training.repository.TrainingProgramRepository;
+import team.startup.expo.global.annotation.TransactionService;
+
+@TransactionService
+@RequiredArgsConstructor
+public class DeleteExpoServiceImpl implements DeleteExpoService {
+
+    private final ExpoRepository expoRepository;
+    private final StandardProgramRepository standardProgramRepository;
+    private final ParticipantRepository participantRepository;
+    private final TraineeRepository traineeRepository;
+    private final TrainingProgramRepository trainingProgramRepository;
+    private final UserUtil userUtil;
+
+    public void execute(Long expoId) {
+        Admin admin = userUtil.getCurrentUser();
+
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(NotFoundExpoException::new);
+
+        if (expo.getAdmin() != admin)
+            throw new NotMatchAdminException();
+
+
+        standardProgramRepository.deleteByExpo(expo);
+        trainingProgramRepository.deleteByExpo(expo);
+        participantRepository.deleteByExpo(expo);
+        traineeRepository.deleteByExpo(expo);
+        expoRepository.delete(expo);
+    }
+}

--- a/src/main/java/team/startup/expo/domain/participant/ExpoParticipant.java
+++ b/src/main/java/team/startup/expo/domain/participant/ExpoParticipant.java
@@ -29,7 +29,7 @@ public class ExpoParticipant {
     @Column(nullable = false)
     private Authority authority;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
     private boolean status;
 
     @Column(nullable = false, columnDefinition = "VARCHAR(50)")
@@ -38,12 +38,12 @@ public class ExpoParticipant {
     @Column(nullable = false, columnDefinition = "VARCHAR(20)")
     private String position;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
     private Boolean informationStatus;
 
     private byte[] qrCode;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "expo_id")
     private Expo expo;
 

--- a/src/main/java/team/startup/expo/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/ParticipantRepository.java
@@ -1,10 +1,12 @@
 package team.startup.expo.domain.participant.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import team.startup.expo.domain.expo.Expo;
 import team.startup.expo.domain.participant.ExpoParticipant;
 
 import java.util.Optional;
 
 public interface ParticipantRepository extends JpaRepository<ExpoParticipant, Long> {
     Optional<ExpoParticipant> findByPhoneNumber(String phoneNumber);
+    void deleteByExpo(Expo expo);
 }

--- a/src/main/java/team/startup/expo/domain/standard/StandardProgram.java
+++ b/src/main/java/team/startup/expo/domain/standard/StandardProgram.java
@@ -27,7 +27,7 @@ public class StandardProgram {
     @Column(nullable = false, columnDefinition = "VARCHAR(20)")
     private String endedAt;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "expo_id")
     private Expo expo;
 

--- a/src/main/java/team/startup/expo/domain/standard/StandardProgramUser.java
+++ b/src/main/java/team/startup/expo/domain/standard/StandardProgramUser.java
@@ -18,7 +18,7 @@ public class StandardProgramUser {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
     private Boolean status = false;
 
     @Column(columnDefinition = "VARCHAR(20)")
@@ -27,11 +27,11 @@ public class StandardProgramUser {
     @Column(columnDefinition = "VARCHAR(20)")
     private String leaveTime;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "standardPro_id")
     private StandardProgram standardProgram;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "participant_id")
     private ExpoParticipant expoParticipant;
 }

--- a/src/main/java/team/startup/expo/domain/standard/repository/StandardProgramRepository.java
+++ b/src/main/java/team/startup/expo/domain/standard/repository/StandardProgramRepository.java
@@ -1,0 +1,9 @@
+package team.startup.expo.domain.standard.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.startup.expo.domain.expo.Expo;
+import team.startup.expo.domain.standard.StandardProgram;
+
+public interface StandardProgramRepository extends JpaRepository<StandardProgram, Long> {
+    void deleteByExpo(Expo expo);
+}

--- a/src/main/java/team/startup/expo/domain/trainee/Trainee.java
+++ b/src/main/java/team/startup/expo/domain/trainee/Trainee.java
@@ -22,7 +22,7 @@ public class Trainee {
     @Column(nullable = false, columnDefinition = "VARCHAR(20)")
     private String trainingId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
     private Boolean laptopStatus;
 
     @Column(nullable = false, columnDefinition = "VARCHAR(15)")
@@ -44,12 +44,12 @@ public class Trainee {
     @Column(nullable = false, columnDefinition = "VARCHAR(10)")
     private String name;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
     private Boolean informationStatus;
 
     private byte[] qrCode;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "expo_id")
     private Expo expo;
 

--- a/src/main/java/team/startup/expo/domain/trainee/repository/TraineeRepository.java
+++ b/src/main/java/team/startup/expo/domain/trainee/repository/TraineeRepository.java
@@ -1,10 +1,12 @@
 package team.startup.expo.domain.trainee.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import team.startup.expo.domain.expo.Expo;
 import team.startup.expo.domain.trainee.Trainee;
 
 import java.util.Optional;
 
 public interface TraineeRepository extends JpaRepository<Trainee, Long> {
     Optional<Trainee> findByPhoneNumber(String phoneNumber);
+    void deleteByExpo(Expo expo);
 }

--- a/src/main/java/team/startup/expo/domain/training/TrainingProgram.java
+++ b/src/main/java/team/startup/expo/domain/training/TrainingProgram.java
@@ -32,7 +32,7 @@ public class TrainingProgram {
     @Column(nullable = false)
     private Category category;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "expo_id")
     private Expo expo;
 }

--- a/src/main/java/team/startup/expo/domain/training/TrainingProgramUser.java
+++ b/src/main/java/team/startup/expo/domain/training/TrainingProgramUser.java
@@ -18,7 +18,7 @@ public class TrainingProgramUser {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
     private Boolean status = false;
 
     @Column(columnDefinition = "VARCHAR(20)")
@@ -27,7 +27,7 @@ public class TrainingProgramUser {
     @Column(columnDefinition = "VARCHAR(20)")
     private String leaveTime;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "trainingPro_id")
     private TrainingProgram trainingProgram;
 

--- a/src/main/java/team/startup/expo/domain/training/repository/TrainingProgramRepository.java
+++ b/src/main/java/team/startup/expo/domain/training/repository/TrainingProgramRepository.java
@@ -1,7 +1,9 @@
 package team.startup.expo.domain.training.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import team.startup.expo.domain.expo.Expo;
 import team.startup.expo.domain.training.TrainingProgram;
 
 public interface TrainingProgramRepository extends JpaRepository<TrainingProgram, Long> {
+    void deleteByExpo(Expo expo);
 }

--- a/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
@@ -83,6 +83,7 @@ public class SecurityConfig {
                                 // expo
                                 .requestMatchers(HttpMethod.POST, "/expo").hasAnyAuthority(Authority.ROLE_ADMIN.name())
                                 .requestMatchers(HttpMethod.PATCH, "/expo/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
+                                .requestMatchers(HttpMethod.DELETE, "/expo/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
 
                                 //image
                                 .requestMatchers(HttpMethod.POST, "/image").authenticated()


### PR DESCRIPTION
## 💡 배경 및 개요

박람회 삭제와 삭제하는 동시에 관련된 연수 프로그램, 일반 프로그램, 연수자, 박람회 방문자 들을 동시에 삭제하는 로직을 추가하였습니다.

Resolves: #{이슈번호}

## 📃 작업내용

* DeleteExpo api 추가
* Expo와 관련된 엔티티 cascade 적용

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타