### PR TITLE
🔀 :: 박람회 입장 전 출석 api

### DIFF
--- a/src/main/java/team/startup/expo/domain/attendance/exception/AlreadyEnterExpoUserException.java
+++ b/src/main/java/team/startup/expo/domain/attendance/exception/AlreadyEnterExpoUserException.java
@@ -1,0 +1,10 @@
+package team.startup.expo.domain.attendance.exception;
+
+import team.startup.expo.global.exception.ErrorCode;
+import team.startup.expo.global.exception.GlobalException;
+
+public class AlreadyEnterExpoUserException extends GlobalException {
+    public AlreadyEnterExpoUserException() {
+        super(ErrorCode.ALREADY_ENTER_EXPO_USER);
+    }
+}

--- a/src/main/java/team/startup/expo/domain/attendance/presentation/AttendanceController.java
+++ b/src/main/java/team/startup/expo/domain/attendance/presentation/AttendanceController.java
@@ -3,8 +3,10 @@ package team.startup.expo.domain.attendance.presentation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import team.startup.expo.domain.attendance.presentation.dto.request.PreEnterScanQrCodeRequestDto;
 import team.startup.expo.domain.attendance.presentation.dto.request.ScanStandardProRequestDto;
 import team.startup.expo.domain.attendance.presentation.dto.request.ScanTrainingProRequestDto;
+import team.startup.expo.domain.attendance.service.PreEnterScanQrCodeService;
 import team.startup.expo.domain.attendance.service.ScanStandardProByQrCodeService;
 import team.startup.expo.domain.attendance.service.ScanTrainingProByQrCodeService;
 
@@ -15,6 +17,7 @@ public class AttendanceController {
 
     private final ScanTrainingProByQrCodeService scanTrainingProByQrCodeService;
     private final ScanStandardProByQrCodeService scanStandardProByQrCodeService;
+    private final PreEnterScanQrCodeService preEnterScanQrCodeService;
 
     @PatchMapping("/training/{trainingPro_id}")
     public ResponseEntity<Void> scanTrainingProByQrCode(
@@ -31,6 +34,12 @@ public class AttendanceController {
         @RequestBody ScanStandardProRequestDto dto
     ) {
         scanStandardProByQrCodeService.execute(standardProId, dto);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping
+    public ResponseEntity<Void> preEnterScanQrCode(@RequestBody PreEnterScanQrCodeRequestDto dto) {
+        preEnterScanQrCodeService.execute(dto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/team/startup/expo/domain/attendance/presentation/dto/request/PreEnterScanQrCodeRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/attendance/presentation/dto/request/PreEnterScanQrCodeRequestDto.java
@@ -1,0 +1,16 @@
+package team.startup.expo.domain.attendance.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.startup.expo.domain.admin.Authority;
+
+@NoArgsConstructor
+@Getter
+public class PreEnterScanQrCodeRequestDto {
+    @NotNull
+    private Authority authority;
+
+    @NotNull
+    private String phoneNumber;
+}

--- a/src/main/java/team/startup/expo/domain/attendance/service/PreEnterScanQrCodeService.java
+++ b/src/main/java/team/startup/expo/domain/attendance/service/PreEnterScanQrCodeService.java
@@ -1,0 +1,7 @@
+package team.startup.expo.domain.attendance.service;
+
+import team.startup.expo.domain.attendance.presentation.dto.request.PreEnterScanQrCodeRequestDto;
+
+public interface PreEnterScanQrCodeService {
+    void execute(PreEnterScanQrCodeRequestDto dto);
+}

--- a/src/main/java/team/startup/expo/domain/attendance/service/impl/PreEnterScanQrCodeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/attendance/service/impl/PreEnterScanQrCodeServiceImpl.java
@@ -1,0 +1,42 @@
+package team.startup.expo.domain.attendance.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import team.startup.expo.domain.admin.Authority;
+import team.startup.expo.domain.attendance.exception.AlreadyEnterExpoUserException;
+import team.startup.expo.domain.attendance.presentation.dto.request.PreEnterScanQrCodeRequestDto;
+import team.startup.expo.domain.attendance.service.PreEnterScanQrCodeService;
+import team.startup.expo.domain.participant.ExpoParticipant;
+import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.sms.exception.NotFoundParticipantException;
+import team.startup.expo.domain.sms.exception.NotFoundTraineeException;
+import team.startup.expo.domain.trainee.Trainee;
+import team.startup.expo.domain.trainee.repository.TraineeRepository;
+import team.startup.expo.global.annotation.TransactionService;
+
+@TransactionService
+@RequiredArgsConstructor
+public class PreEnterScanQrCodeServiceImpl implements PreEnterScanQrCodeService {
+
+    private final TraineeRepository traineeRepository;
+    private final ParticipantRepository participantRepository;
+
+    public void execute(PreEnterScanQrCodeRequestDto dto) {
+        if (dto.getAuthority() == Authority.ROLE_STANDARD) {
+            ExpoParticipant participant = participantRepository.findByPhoneNumber(dto.getPhoneNumber())
+                    .orElseThrow(NotFoundParticipantException::new);
+
+            if (participant.getAttendanceStatus())
+                throw new AlreadyEnterExpoUserException();
+
+            participant.changeAttendanceStatus();
+        } else if (dto.getAuthority() == Authority.ROLE_TRAINEE) {
+            Trainee trainee = traineeRepository.findByPhoneNumber(dto.getPhoneNumber())
+                    .orElseThrow(NotFoundTraineeException::new);
+
+            if (trainee.getAttendanceStatus())
+                throw new AlreadyEnterExpoUserException();
+
+            trainee.changeAttendanceStatus();
+        }
+    }
+}

--- a/src/main/java/team/startup/expo/domain/participant/ExpoParticipant.java
+++ b/src/main/java/team/startup/expo/domain/participant/ExpoParticipant.java
@@ -41,6 +41,9 @@ public class ExpoParticipant {
     @Column(nullable = false, columnDefinition = "TINYINT(1)")
     private Boolean informationStatus;
 
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
+    private Boolean attendanceStatus = false;
+
     private byte[] qrCode;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -49,5 +52,9 @@ public class ExpoParticipant {
 
     public void addQrCode(byte[] qrCode) {
         this.qrCode = qrCode;
+    }
+
+    public void changeAttendanceStatus() {
+        this.attendanceStatus = true;
     }
 }

--- a/src/main/java/team/startup/expo/domain/trainee/Trainee.java
+++ b/src/main/java/team/startup/expo/domain/trainee/Trainee.java
@@ -47,6 +47,9 @@ public class Trainee {
     @Column(nullable = false, columnDefinition = "TINYINT(1)")
     private Boolean informationStatus;
 
+    @Column(nullable = false, columnDefinition = "TINYINT(1)")
+    private Boolean attendanceStatus = false;
+
     private byte[] qrCode;
 
     @ManyToOne
@@ -55,5 +58,9 @@ public class Trainee {
 
     public void addQrCode(byte[] qrCode) {
         this.qrCode = qrCode;
+    }
+
+    public void changeAttendanceStatus() {
+        this.attendanceStatus = true;
     }
 }

--- a/src/main/java/team/startup/expo/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/expo/global/exception/ErrorCode.java
@@ -47,6 +47,9 @@ public enum ErrorCode {
     // participant
     NOT_FOUND_PARTICIPANT(404, "행사 참가자를 찾지 못 했습니다."),
 
+    // attendance
+    ALREADY_ENTER_EXPO_USER(400, "이미 박람회에 입장한 유저입니다."),
+
     // trainee
     NOT_FOUND_TRAINEE(404, "연수자를 찾지 못 했습니다."),
 

--- a/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
@@ -99,6 +99,7 @@ public class SecurityConfig {
                                 // attendance
                                 .requestMatchers(HttpMethod.PATCH, "/attendance/training/{trainingPro_id}").permitAll()
                                 .requestMatchers(HttpMethod.PATCH, "/attendance/standard/{standardPro_id}").permitAll()
+                                .requestMatchers(HttpMethod.PATCH, "/attendance").permitAll()
 
                                 //image
                                 .requestMatchers(HttpMethod.POST, "/image").authenticated()


### PR DESCRIPTION
## 💡 배경 및 개요

박람회를 입장 하기 전 네임텍을 출력할 때 박람회에 출석여부를 판단하기 위해 추가하였습니다

Resolves: #77 

## 📃 작업내용

* PreEnterScanQrCode api 추가
* Trainee, ExpoParticipant에 attendanceStatus 추가

## 🙋‍♂️ 리뷰노트

attendanceStatus를 추가하여 ERD가 수정되었습니다

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타