### PR TITLE
🔀 :: Expo 엔티티의 id 타입 변경

### DIFF
--- a/src/main/java/team/startup/expo/domain/expo/Expo.java
+++ b/src/main/java/team/startup/expo/domain/expo/Expo.java
@@ -15,8 +15,8 @@ import team.startup.expo.domain.admin.Admin;
 public class Expo {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(nullable = false, unique = true, columnDefinition = "VARCHAR(36)")
+    private String id;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String title;

--- a/src/main/java/team/startup/expo/domain/expo/presentation/ExpoController.java
+++ b/src/main/java/team/startup/expo/domain/expo/presentation/ExpoController.java
@@ -27,8 +27,8 @@ public class ExpoController {
 
     @PostMapping
     public ResponseEntity<GenerateExpoResponseDto> generateExpo(@RequestBody @Valid GenerateExpoRequestDto dto) {
-        generateExpoService.execute(dto);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        GenerateExpoResponseDto response = generateExpoService.execute(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PatchMapping("/{expo_id}")

--- a/src/main/java/team/startup/expo/domain/expo/presentation/ExpoController.java
+++ b/src/main/java/team/startup/expo/domain/expo/presentation/ExpoController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team.startup.expo.domain.expo.presentation.dto.request.GenerateExpoRequestDto;
 import team.startup.expo.domain.expo.presentation.dto.request.UpdateExpoRequestDto;
+import team.startup.expo.domain.expo.presentation.dto.response.GenerateExpoResponseDto;
 import team.startup.expo.domain.expo.presentation.dto.response.GetExpoInfoResponseDto;
 import team.startup.expo.domain.expo.presentation.dto.response.GetExpoResponseDto;
 import team.startup.expo.domain.expo.service.*;
@@ -25,25 +26,25 @@ public class ExpoController {
     private final GetExpoListService getExpoListService;
 
     @PostMapping
-    public ResponseEntity<Void> generateExpo(@RequestBody @Valid GenerateExpoRequestDto dto) {
+    public ResponseEntity<GenerateExpoResponseDto> generateExpo(@RequestBody @Valid GenerateExpoRequestDto dto) {
         generateExpoService.execute(dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PatchMapping("/{expo_id}")
-    public ResponseEntity<Void> updateExpo(@PathVariable("expo_id") Long expoId, @RequestBody @Valid UpdateExpoRequestDto dto) {
+    public ResponseEntity<Void> updateExpo(@PathVariable("expo_id") String expoId, @RequestBody @Valid UpdateExpoRequestDto dto) {
         updateExpoService.execute(expoId, dto);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @DeleteMapping("/{expo_id}")
-    public ResponseEntity<Void> deleteExpo(@PathVariable("expo_id") Long expoId) {
+    public ResponseEntity<Void> deleteExpo(@PathVariable("expo_id") String expoId) {
         deleteExpoService.execute(expoId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @GetMapping("/{expo_id}")
-    public ResponseEntity<GetExpoInfoResponseDto> getExpoInfo(@PathVariable("expo_id") Long expoId) {
+    public ResponseEntity<GetExpoInfoResponseDto> getExpoInfo(@PathVariable("expo_id") String expoId) {
         GetExpoInfoResponseDto response = getExpoInfoService.execute(expoId);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/team/startup/expo/domain/expo/presentation/dto/request/GenerateExpoRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/expo/presentation/dto/request/GenerateExpoRequestDto.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
@@ -19,14 +19,12 @@ public class GenerateExpoRequestDto {
     private String description;
 
     @NotNull
-    @Size(max = 20)
     @JsonFormat(pattern = "yyyy-MM-dd")
-    private LocalDateTime startedDay;
+    private LocalDate startedDay;
 
     @NotNull
-    @Size(max = 20)
     @JsonFormat(pattern = "yyyy-MM-dd")
-    private LocalDateTime finishedDay;
+    private LocalDate finishedDay;
 
     @NotNull
     private String location;

--- a/src/main/java/team/startup/expo/domain/expo/presentation/dto/request/UpdateExpoRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/expo/presentation/dto/request/UpdateExpoRequestDto.java
@@ -20,12 +20,10 @@ public class UpdateExpoRequestDto {
     private String description;
 
     @NotNull
-    @Size(max = 20)
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDateTime startedDay;
 
     @NotNull
-    @Size(max = 20)
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDateTime finishedDay;
 

--- a/src/main/java/team/startup/expo/domain/expo/presentation/dto/response/GenerateExpoResponseDto.java
+++ b/src/main/java/team/startup/expo/domain/expo/presentation/dto/response/GenerateExpoResponseDto.java
@@ -1,0 +1,10 @@
+package team.startup.expo.domain.expo.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class GenerateExpoResponseDto {
+    private String expoId;
+}

--- a/src/main/java/team/startup/expo/domain/expo/presentation/dto/response/GetExpoResponseDto.java
+++ b/src/main/java/team/startup/expo/domain/expo/presentation/dto/response/GetExpoResponseDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class GetExpoResponseDto {
-    private Long id;
+    private String id;
     private String title;
     private String description;
     private String startedDay;

--- a/src/main/java/team/startup/expo/domain/expo/repository/ExpoRepository.java
+++ b/src/main/java/team/startup/expo/domain/expo/repository/ExpoRepository.java
@@ -3,5 +3,5 @@ package team.startup.expo.domain.expo.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.startup.expo.domain.expo.Expo;
 
-public interface ExpoRepository extends JpaRepository<Expo, Long> {
+public interface ExpoRepository extends JpaRepository<Expo, String> {
 }

--- a/src/main/java/team/startup/expo/domain/expo/service/DeleteExpoService.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/DeleteExpoService.java
@@ -1,5 +1,5 @@
 package team.startup.expo.domain.expo.service;
 
 public interface DeleteExpoService {
-    void execute(Long expoId);
+    void execute(String expoId);
 }

--- a/src/main/java/team/startup/expo/domain/expo/service/GenerateExpoService.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/GenerateExpoService.java
@@ -1,7 +1,8 @@
 package team.startup.expo.domain.expo.service;
 
 import team.startup.expo.domain.expo.presentation.dto.request.GenerateExpoRequestDto;
+import team.startup.expo.domain.expo.presentation.dto.response.GenerateExpoResponseDto;
 
 public interface GenerateExpoService {
-    void execute(GenerateExpoRequestDto dto);
+    GenerateExpoResponseDto execute(GenerateExpoRequestDto dto);
 }

--- a/src/main/java/team/startup/expo/domain/expo/service/GetExpoInfoService.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/GetExpoInfoService.java
@@ -3,5 +3,5 @@ package team.startup.expo.domain.expo.service;
 import team.startup.expo.domain.expo.presentation.dto.response.GetExpoInfoResponseDto;
 
 public interface GetExpoInfoService {
-    GetExpoInfoResponseDto execute(Long expoId);
+    GetExpoInfoResponseDto execute(String expoId);
 }

--- a/src/main/java/team/startup/expo/domain/expo/service/UpdateExpoService.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/UpdateExpoService.java
@@ -3,5 +3,5 @@ package team.startup.expo.domain.expo.service;
 import team.startup.expo.domain.expo.presentation.dto.request.UpdateExpoRequestDto;
 
 public interface UpdateExpoService {
-    void execute(Long expoId, UpdateExpoRequestDto dto);
+    void execute(String expoId, UpdateExpoRequestDto dto);
 }

--- a/src/main/java/team/startup/expo/domain/expo/service/impl/DeleteExpoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/impl/DeleteExpoServiceImpl.java
@@ -25,7 +25,7 @@ public class DeleteExpoServiceImpl implements DeleteExpoService {
     private final TrainingProgramRepository trainingProgramRepository;
     private final UserUtil userUtil;
 
-    public void execute(Long expoId) {
+    public void execute(String expoId) {
         Admin admin = userUtil.getCurrentUser();
 
         Expo expo = expoRepository.findById(expoId)

--- a/src/main/java/team/startup/expo/domain/expo/service/impl/GenerateExpoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/impl/GenerateExpoServiceImpl.java
@@ -5,9 +5,11 @@ import team.startup.expo.domain.admin.Admin;
 import team.startup.expo.domain.admin.util.UserUtil;
 import team.startup.expo.domain.expo.Expo;
 import team.startup.expo.domain.expo.presentation.dto.request.GenerateExpoRequestDto;
+import team.startup.expo.domain.expo.presentation.dto.response.GenerateExpoResponseDto;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.expo.service.GenerateExpoService;
 import team.startup.expo.global.annotation.TransactionService;
+import team.startup.expo.global.common.ulid.ULIDGenerator;
 
 @TransactionService
 @RequiredArgsConstructor
@@ -16,14 +18,19 @@ public class GenerateExpoServiceImpl implements GenerateExpoService {
     private final ExpoRepository expoRepository;
     private final UserUtil userUtil;
 
-    public void execute(GenerateExpoRequestDto dto) {
+    public GenerateExpoResponseDto execute(GenerateExpoRequestDto dto) {
         Admin admin = userUtil.getCurrentUser();
 
-        saveExpo(dto, admin);
+        String expoId = saveExpo(dto, admin);
+
+        return GenerateExpoResponseDto.builder()
+                .expoId(expoId)
+                .build();
     }
 
-    private void saveExpo(GenerateExpoRequestDto dto, Admin admin) {
+    private String saveExpo(GenerateExpoRequestDto dto, Admin admin) {
         Expo expo = Expo.builder()
+                .id(ULIDGenerator.generateULID())
                 .title(dto.getTitle())
                 .description(dto.getDescription())
                 .startedDay(String.valueOf(dto.getStartedDay()))
@@ -36,5 +43,7 @@ public class GenerateExpoServiceImpl implements GenerateExpoService {
                 .build();
 
         expoRepository.save(expo);
+
+        return expo.getId();
     }
 }

--- a/src/main/java/team/startup/expo/domain/expo/service/impl/GetExpoInfoInfoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/impl/GetExpoInfoInfoServiceImpl.java
@@ -14,7 +14,7 @@ public class GetExpoInfoInfoServiceImpl implements GetExpoInfoService {
 
     private final ExpoRepository expoRepository;
 
-    public GetExpoInfoResponseDto execute(Long expoId) {
+    public GetExpoInfoResponseDto execute(String expoId) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 

--- a/src/main/java/team/startup/expo/domain/expo/service/impl/GetExpoListServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/impl/GetExpoListServiceImpl.java
@@ -5,6 +5,7 @@ import team.startup.expo.domain.expo.presentation.dto.response.GetExpoResponseDt
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.expo.service.GetExpoListService;
 import team.startup.expo.global.annotation.ReadOnlyTransactionService;
+import team.startup.expo.global.common.ulid.ULIDGenerator;
 
 import java.util.List;
 
@@ -13,6 +14,7 @@ import java.util.List;
 public class GetExpoListServiceImpl implements GetExpoListService {
 
     private final ExpoRepository expoRepository;
+    private final ULIDGenerator ulidGenerator;
 
     public List<GetExpoResponseDto> execute() {
         return expoRepository.findAll().stream()

--- a/src/main/java/team/startup/expo/domain/expo/service/impl/UpdateExpoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/impl/UpdateExpoServiceImpl.java
@@ -18,7 +18,7 @@ public class UpdateExpoServiceImpl implements UpdateExpoService {
     private final ExpoRepository expoRepository;
     private final UserUtil userUtil;
 
-    public void execute(Long expoId, UpdateExpoRequestDto dto) {
+    public void execute(String expoId, UpdateExpoRequestDto dto) {
         Admin admin = userUtil.getCurrentUser();
 
         Expo expo = expoRepository.findById(expoId)

--- a/src/main/java/team/startup/expo/domain/standard/presentation/StandardController.java
+++ b/src/main/java/team/startup/expo/domain/standard/presentation/StandardController.java
@@ -23,13 +23,13 @@ public class StandardController {
     private final UpdateStandardProService updateStandardProService;
 
     @PostMapping("/{expo_id}")
-    public ResponseEntity<Void> addStandardPro(@PathVariable("expo_id") Long expoId, @RequestBody @Valid AddStandardProRequestDto dto) {
+    public ResponseEntity<Void> addStandardPro(@PathVariable("expo_id") String expoId, @RequestBody @Valid AddStandardProRequestDto dto) {
         addStandardProService.execute(expoId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PostMapping("/list/{expo_id}")
-    public ResponseEntity<Void> addStandardProList(@PathVariable("expo_id") Long expoId, @RequestBody @Valid List<AddStandardProRequestDto> dtos) {
+    public ResponseEntity<Void> addStandardProList(@PathVariable("expo_id") String expoId, @RequestBody @Valid List<AddStandardProRequestDto> dtos) {
         addStandardProListService.execute(expoId, dtos);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/team/startup/expo/domain/standard/presentation/dto/request/AddStandardProRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/standard/presentation/dto/request/AddStandardProRequestDto.java
@@ -17,12 +17,10 @@ public class AddStandardProRequestDto {
     private String title;
 
     @NotNull
-    @Size(max = 20)
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime startedAt;
 
     @NotNull
-    @Size(max = 20)
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime endedAt;
 }

--- a/src/main/java/team/startup/expo/domain/standard/presentation/dto/request/UpdateStandardProRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/standard/presentation/dto/request/UpdateStandardProRequestDto.java
@@ -13,16 +13,13 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class UpdateStandardProRequestDto {
     @NotNull
-    @Size(max = 100)
     private String title;
 
     @NotNull
-    @Size(max = 20)
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime startedAt;
 
     @NotNull
-    @Size(max = 20)
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime endedAt;
 

--- a/src/main/java/team/startup/expo/domain/standard/service/AddStandardProListService.java
+++ b/src/main/java/team/startup/expo/domain/standard/service/AddStandardProListService.java
@@ -5,5 +5,5 @@ import team.startup.expo.domain.standard.presentation.dto.request.AddStandardPro
 import java.util.List;
 
 public interface AddStandardProListService {
-    void execute(Long expoId, List<AddStandardProRequestDto> dtos);
+    void execute(String expoId, List<AddStandardProRequestDto> dtos);
 }

--- a/src/main/java/team/startup/expo/domain/standard/service/AddStandardProService.java
+++ b/src/main/java/team/startup/expo/domain/standard/service/AddStandardProService.java
@@ -3,5 +3,5 @@ package team.startup.expo.domain.standard.service;
 import team.startup.expo.domain.standard.presentation.dto.request.AddStandardProRequestDto;
 
 public interface AddStandardProService {
-    void execute(Long expoId, AddStandardProRequestDto dto);
+    void execute(String expoId, AddStandardProRequestDto dto);
 }

--- a/src/main/java/team/startup/expo/domain/standard/service/impl/AddStandardProListServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/standard/service/impl/AddStandardProListServiceImpl.java
@@ -19,7 +19,7 @@ public class AddStandardProListServiceImpl implements AddStandardProListService 
     private final StandardProgramRepository standardProgramRepository;
     private final ExpoRepository expoRepository;
 
-    public void execute(Long expoId, List<AddStandardProRequestDto> dtos) {
+    public void execute(String expoId, List<AddStandardProRequestDto> dtos) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 

--- a/src/main/java/team/startup/expo/domain/standard/service/impl/AddStandardProServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/standard/service/impl/AddStandardProServiceImpl.java
@@ -17,7 +17,7 @@ public class AddStandardProServiceImpl implements AddStandardProService {
     private final StandardProgramRepository standardProgramRepository;
     private final ExpoRepository expoRepository;
 
-    public void execute(Long expoId, AddStandardProRequestDto dto) {
+    public void execute(String expoId, AddStandardProRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 

--- a/src/main/java/team/startup/expo/domain/training/presentation/TrainingController.java
+++ b/src/main/java/team/startup/expo/domain/training/presentation/TrainingController.java
@@ -32,7 +32,7 @@ public class TrainingController {
     }
 
     @PostMapping("/{expo_id}")
-    public ResponseEntity<Void> addTrainingPro(@PathVariable("expo_id") Long expoId, @RequestBody @Valid AddTrainingProRequestDto dto) {
+    public ResponseEntity<Void> addTrainingPro(@PathVariable("expo_id") String expoId, @RequestBody @Valid AddTrainingProRequestDto dto) {
         addTrainingProService.execute(expoId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
@@ -50,13 +50,13 @@ public class TrainingController {
     }
 
     @GetMapping("/program/{expo_id}")
-    public ResponseEntity<List<GetTrainingProResponse>> getTrainingProList(@PathVariable("expo_id") Long expoId) {
+    public ResponseEntity<List<GetTrainingProResponse>> getTrainingProList(@PathVariable("expo_id") String expoId) {
         List<GetTrainingProResponse> response = getTrainingProListService.execute(expoId);
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/list/{expo_id}")
-    public ResponseEntity<Void> addTrainingProList(@PathVariable("expo_id") Long expoId, @RequestBody @Valid List<AddTrainingProRequestDto> dtos) {
+    public ResponseEntity<Void> addTrainingProList(@PathVariable("expo_id") String expoId, @RequestBody @Valid List<AddTrainingProRequestDto> dtos) {
         addTrainingProListService.execute(expoId, dtos);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/team/startup/expo/domain/training/presentation/dto/request/AddTrainingProRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/training/presentation/dto/request/AddTrainingProRequestDto.java
@@ -18,12 +18,10 @@ public class AddTrainingProRequestDto {
     private String title;
 
     @NotNull
-    @Size(max = 20)
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime startedAt;
 
     @NotNull
-    @Size(max = 20)
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime endedAt;
 

--- a/src/main/java/team/startup/expo/domain/training/presentation/dto/request/UpdateTrainingProRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/training/presentation/dto/request/UpdateTrainingProRequestDto.java
@@ -19,12 +19,10 @@ public class UpdateTrainingProRequestDto {
     private String title;
 
     @NotNull
-    @Size(max = 20)
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime startedAt;
 
     @NotNull
-    @Size(max = 20)
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime endedAt;
 

--- a/src/main/java/team/startup/expo/domain/training/service/AddTrainingProListService.java
+++ b/src/main/java/team/startup/expo/domain/training/service/AddTrainingProListService.java
@@ -5,5 +5,5 @@ import team.startup.expo.domain.training.presentation.dto.request.AddTrainingPro
 import java.util.List;
 
 public interface AddTrainingProListService {
-    void execute(Long expoId, List<AddTrainingProRequestDto> dtos);
+    void execute(String expoId, List<AddTrainingProRequestDto> dtos);
 }

--- a/src/main/java/team/startup/expo/domain/training/service/AddTrainingProService.java
+++ b/src/main/java/team/startup/expo/domain/training/service/AddTrainingProService.java
@@ -3,5 +3,5 @@ package team.startup.expo.domain.training.service;
 import team.startup.expo.domain.training.presentation.dto.request.AddTrainingProRequestDto;
 
 public interface AddTrainingProService {
-    void execute(Long expoId, AddTrainingProRequestDto dto);
+    void execute(String expoId, AddTrainingProRequestDto dto);
 }

--- a/src/main/java/team/startup/expo/domain/training/service/GetTrainingProListService.java
+++ b/src/main/java/team/startup/expo/domain/training/service/GetTrainingProListService.java
@@ -5,5 +5,5 @@ import team.startup.expo.domain.training.presentation.dto.response.GetTrainingPr
 import java.util.List;
 
 public interface GetTrainingProListService {
-    List<GetTrainingProResponse> execute(Long expoId);
+    List<GetTrainingProResponse> execute(String expoId);
 }

--- a/src/main/java/team/startup/expo/domain/training/service/impl/AddTrainingProListServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/training/service/impl/AddTrainingProListServiceImpl.java
@@ -19,7 +19,7 @@ public class AddTrainingProListServiceImpl implements AddTrainingProListService 
     private final TrainingProgramRepository trainingProgramRepository;
     private final ExpoRepository expoRepository;
 
-    public void execute(Long expoId, List<AddTrainingProRequestDto> dtos) {
+    public void execute(String expoId, List<AddTrainingProRequestDto> dtos) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 

--- a/src/main/java/team/startup/expo/domain/training/service/impl/AddTrainingProServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/training/service/impl/AddTrainingProServiceImpl.java
@@ -21,7 +21,7 @@ public class AddTrainingProServiceImpl implements AddTrainingProService {
     private final TrainingProgramRepository trainingProgramRepository;
     private final UserUtil userUtil;
 
-    public void execute(Long expoId, AddTrainingProRequestDto dto) {
+    public void execute(String expoId, AddTrainingProRequestDto dto) {
         Admin admin = userUtil.getCurrentUser();
 
         Expo expo = expoRepository.findById(expoId)

--- a/src/main/java/team/startup/expo/domain/training/service/impl/GetTrainingProListServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/training/service/impl/GetTrainingProListServiceImpl.java
@@ -18,7 +18,7 @@ public class GetTrainingProListServiceImpl implements GetTrainingProListService 
     private final TrainingProgramRepository trainingProgramRepository;
     private final ExpoRepository expoRepository;
 
-    public List<GetTrainingProResponse> execute(Long expoId) {
+    public List<GetTrainingProResponse> execute(String expoId) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 

--- a/src/main/java/team/startup/expo/global/common/ulid/ULIDGenerator.java
+++ b/src/main/java/team/startup/expo/global/common/ulid/ULIDGenerator.java
@@ -1,0 +1,44 @@
+package team.startup.expo.global.common.ulid;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.IdentifierGenerator;
+import org.springframework.stereotype.Component;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.SecureRandom;
+import java.time.Instant;
+
+@Component
+public class ULIDGenerator implements IdentifierGenerator {
+
+    private static final SecureRandom random = new SecureRandom();
+
+    public Object generate(SharedSessionContractImplementor sharedSessionContractImplementor, Object object) {
+        return generateULID();
+    }
+
+    public static String generateULID() {
+        long milliseconds = Instant.now().toEpochMilli();
+
+        byte[] bytes = new byte[16];
+        ByteBuffer buffer = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN);
+        buffer.putLong(milliseconds);
+        buffer.putLong(random.nextLong());
+
+        return fromString(bytes);
+    }
+
+    public static String fromString(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < bytes.length; i++) {
+            if (i == 6 || i == 8 || i == 10 || i == 12) {
+                sb.append('-');
+            }
+            int value = bytes[i] & 0xFF;
+            sb.append(Integer.toHexString(value >>> 4));
+            sb.append(Integer.toHexString(value & 0x0F));
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요

박람회를 생성하는 과정에서 연수 혹은 일반 프로그램을 등록해야되는 상황에 id를 데이터베이스에 위임하여 id 값을 알 수 없어 UUID는 정렬이 되지 않는 단점때문에 ULID를 직접 생성하여 반환하는 방식으로 하였습니다

Resolves: #87 

## 📃 작업내용

* ULIDGenerator 추가
* expo_id를 Long -> String 변경

## 🙋‍♂️ 리뷰노트

나중에 ULID보다 더 좋은 방법이 있다면 수정하는 방식이 좋을 것 같습니다.
지금은 떠오르는 방법이 ULID밖에 없어 적용하였습니다.

또한, Dto에 LocalDate에 적용하였던 Size 어노테이션에 문제가 생겨 임시로 삭제하였습니다

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타