### PR TITLE
🔀 :: 일반 참가자 사전 신청

### DIFF
--- a/src/main/java/team/startup/expo/domain/form/presentation/FormController.java
+++ b/src/main/java/team/startup/expo/domain/form/presentation/FormController.java
@@ -5,7 +5,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import team.startup.expo.domain.form.presentation.dto.request.PreApplicationForParticipantRequestDto;
 import team.startup.expo.domain.form.presentation.dto.request.PreApplicationForTraineeRequestDto;
+import team.startup.expo.domain.form.service.PreApplicationForParticipantService;
 import team.startup.expo.domain.form.service.PreApplicationForTraineeService;
 
 @RestController
@@ -14,10 +16,17 @@ import team.startup.expo.domain.form.service.PreApplicationForTraineeService;
 public class FormController {
 
     private final PreApplicationForTraineeService preApplicationForTraineeService;
+    private final PreApplicationForParticipantService preApplicationForParticipantService;
 
     @PostMapping("/{expo_id}")
     public ResponseEntity<Void> preApplicationForTrainee(@PathVariable("expo_id") String expoId, @RequestBody @Valid PreApplicationForTraineeRequestDto dto) {
         preApplicationForTraineeService.execute(expoId, dto);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/pre-standard/{expo_id}")
+    public ResponseEntity<Void> preApplicationForParticipant(@PathVariable("expo_id") String expoId, @RequestBody @Valid PreApplicationForParticipantRequestDto dto) {
+        preApplicationForParticipantService.execute(expoId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/team/startup/expo/domain/form/presentation/dto/request/PreApplicationForParticipantRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/form/presentation/dto/request/PreApplicationForParticipantRequestDto.java
@@ -1,0 +1,25 @@
+package team.startup.expo.domain.form.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PreApplicationForParticipantRequestDto {
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private String phoneNumber;
+
+    @NotNull
+    private String affiliation;
+
+    @NotNull
+    private String position;
+
+    @NotNull
+    private Boolean informationStatus;
+}

--- a/src/main/java/team/startup/expo/domain/form/service/PreApplicationForParticipantService.java
+++ b/src/main/java/team/startup/expo/domain/form/service/PreApplicationForParticipantService.java
@@ -1,0 +1,7 @@
+package team.startup.expo.domain.form.service;
+
+import team.startup.expo.domain.form.presentation.dto.request.PreApplicationForParticipantRequestDto;
+
+public interface PreApplicationForParticipantService {
+    void execute(String expoId, PreApplicationForParticipantRequestDto dto);
+}

--- a/src/main/java/team/startup/expo/domain/form/service/impl/PreApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/PreApplicationForParticipantServiceImpl.java
@@ -1,0 +1,42 @@
+package team.startup.expo.domain.form.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import team.startup.expo.domain.admin.Authority;
+import team.startup.expo.domain.expo.Expo;
+import team.startup.expo.domain.expo.exception.NotFoundExpoException;
+import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.form.presentation.dto.request.PreApplicationForParticipantRequestDto;
+import team.startup.expo.domain.form.service.PreApplicationForParticipantService;
+import team.startup.expo.domain.participant.ExpoParticipant;
+import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.global.annotation.TransactionService;
+
+@TransactionService
+@RequiredArgsConstructor
+public class PreApplicationForParticipantServiceImpl implements PreApplicationForParticipantService {
+
+    private final ExpoRepository expoRepository;
+    private final ParticipantRepository participantRepository;
+
+    public void execute(String expoId, PreApplicationForParticipantRequestDto dto) {
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(NotFoundExpoException::new);
+
+        saveParticipant(expo, dto);
+    }
+
+    private void saveParticipant(Expo expo, PreApplicationForParticipantRequestDto dto) {
+        ExpoParticipant expoParticipant = ExpoParticipant.builder()
+                .name(dto.getName())
+                .affiliation(dto.getAffiliation())
+                .phoneNumber(dto.getPhoneNumber())
+                .authority(Authority.ROLE_STANDARD)
+                .attendanceStatus(false)
+                .informationStatus(dto.getInformationStatus())
+                .position(dto.getPosition())
+                .expo(expo)
+                .build();
+
+        participantRepository.save(expoParticipant);
+    }
+}

--- a/src/main/java/team/startup/expo/domain/form/service/impl/PreApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/PreApplicationForParticipantServiceImpl.java
@@ -9,6 +9,7 @@ import team.startup.expo.domain.form.presentation.dto.request.PreApplicationForP
 import team.startup.expo.domain.form.service.PreApplicationForParticipantService;
 import team.startup.expo.domain.participant.ExpoParticipant;
 import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.trainee.ParticipationType;
 import team.startup.expo.global.annotation.TransactionService;
 
 @TransactionService
@@ -32,6 +33,7 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
                 .phoneNumber(dto.getPhoneNumber())
                 .authority(Authority.ROLE_STANDARD)
                 .attendanceStatus(false)
+                .participationType(ParticipationType.PRE)
                 .informationStatus(dto.getInformationStatus())
                 .position(dto.getPosition())
                 .expo(expo)

--- a/src/main/java/team/startup/expo/domain/form/service/impl/PreApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/PreApplicationForTraineeServiceImpl.java
@@ -7,6 +7,7 @@ import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.form.presentation.dto.request.PreApplicationForTraineeRequestDto;
 import team.startup.expo.domain.form.service.PreApplicationForTraineeService;
+import team.startup.expo.domain.trainee.ParticipationType;
 import team.startup.expo.domain.trainee.Trainee;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
 import team.startup.expo.global.annotation.TransactionService;
@@ -35,6 +36,7 @@ public class PreApplicationForTraineeServiceImpl implements PreApplicationForTra
                 .schoolLevel(dto.getSchoolLevel())
                 .organization(dto.getOrganization())
                 .name(dto.getName())
+                .participationType(ParticipationType.PRE)
                 .informationStatus(dto.getInformationStatus())
                 .attendanceStatus(false)
                 .expo(expo)

--- a/src/main/java/team/startup/expo/domain/participant/ExpoParticipant.java
+++ b/src/main/java/team/startup/expo/domain/participant/ExpoParticipant.java
@@ -29,9 +29,6 @@ public class ExpoParticipant {
     @Column(nullable = false)
     private Authority authority;
 
-    @Column(nullable = false, columnDefinition = "TINYINT(1)")
-    private boolean status;
-
     @Column(nullable = false, columnDefinition = "VARCHAR(50)")
     private String affiliation;
 

--- a/src/main/java/team/startup/expo/domain/participant/ExpoParticipant.java
+++ b/src/main/java/team/startup/expo/domain/participant/ExpoParticipant.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team.startup.expo.domain.admin.Authority;
 import team.startup.expo.domain.expo.Expo;
+import team.startup.expo.domain.trainee.ParticipationType;
 
 @Entity
 @NoArgsConstructor
@@ -40,6 +41,10 @@ public class ExpoParticipant {
 
     @Column(nullable = false, columnDefinition = "TINYINT(1)")
     private Boolean attendanceStatus = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ParticipationType participationType;
 
     private byte[] qrCode;
 

--- a/src/main/java/team/startup/expo/domain/trainee/ParticipationType.java
+++ b/src/main/java/team/startup/expo/domain/trainee/ParticipationType.java
@@ -1,0 +1,6 @@
+package team.startup.expo.domain.trainee;
+
+public enum ParticipationType {
+    PRE,
+    FIELD
+}

--- a/src/main/java/team/startup/expo/domain/trainee/Trainee.java
+++ b/src/main/java/team/startup/expo/domain/trainee/Trainee.java
@@ -50,6 +50,10 @@ public class Trainee {
     @Column(nullable = false, columnDefinition = "TINYINT(1)")
     private Boolean attendanceStatus = false;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ParticipationType participationType;
+
     private byte[] qrCode;
 
     @ManyToOne

--- a/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
@@ -109,6 +109,7 @@ public class SecurityConfig {
 
                                 // form
                                 .requestMatchers(HttpMethod.POST, "/form/{expo_id}").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/form/pre-standard/{expo_id}").permitAll()
 
                                 //image
                                 .requestMatchers(HttpMethod.POST, "/image").authenticated()


### PR DESCRIPTION
## 💡 배경 및 개요

일반 참가자가 사전 신청을 할 수 있는 api를 추가하였습니다

Resolves: #97 

## 📃 작업내용

* PreApplicationForParticipant api 추가

## 🙋‍♂️ 리뷰노트

원래 참가 상태를 나타내던 status를 삭제하고 attendanceStatus로 변경하여 가독성을 향샹시켰습니다.
또한, 사전과 현장을 나누기 위해 ParticipationType을 추가하여 나누었습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타