### PR TITLE
🔀 :: 사전 신청 및 현장 참가자 정보 

### DIFF
--- a/src/main/java/team/startup/expo/domain/participant/presentation/ParticipantController.java
+++ b/src/main/java/team/startup/expo/domain/participant/presentation/ParticipantController.java
@@ -1,0 +1,24 @@
+package team.startup.expo.domain.participant.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import team.startup.expo.domain.participant.presentation.dto.response.GetParticipantInfoResponseDto;
+import team.startup.expo.domain.participant.service.GetParticipantInfoService;
+import team.startup.expo.domain.trainee.ParticipationType;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/participant")
+public class ParticipantController {
+
+    private final GetParticipantInfoService getParticipantInfoService;
+
+    @GetMapping("/{expo_id}")
+    public ResponseEntity<List<GetParticipantInfoResponseDto>> getParticipantInfo(@PathVariable("expo_id") String expoId, @RequestParam("type") ParticipationType type) {
+        List<GetParticipantInfoResponseDto> response = getParticipantInfoService.execute(expoId, type);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/team/startup/expo/domain/participant/presentation/dto/response/GetParticipantInfoResponseDto.java
+++ b/src/main/java/team/startup/expo/domain/participant/presentation/dto/response/GetParticipantInfoResponseDto.java
@@ -1,0 +1,15 @@
+package team.startup.expo.domain.participant.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetParticipantInfoResponseDto {
+    private Long id;
+    private String name;
+    private String phoneNumber;
+    private String affiliation;
+    private String position;
+    private Boolean informationStatus;
+}

--- a/src/main/java/team/startup/expo/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/ParticipantRepository.java
@@ -3,10 +3,13 @@ package team.startup.expo.domain.participant.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.startup.expo.domain.expo.Expo;
 import team.startup.expo.domain.participant.ExpoParticipant;
+import team.startup.expo.domain.trainee.ParticipationType;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ParticipantRepository extends JpaRepository<ExpoParticipant, Long> {
     Optional<ExpoParticipant> findByPhoneNumber(String phoneNumber);
     void deleteByExpo(Expo expo);
+    List<ExpoParticipant> findByExpoAndParticipationType(Expo expo, ParticipationType participationType);
 }

--- a/src/main/java/team/startup/expo/domain/participant/service/GetParticipantInfoService.java
+++ b/src/main/java/team/startup/expo/domain/participant/service/GetParticipantInfoService.java
@@ -1,0 +1,10 @@
+package team.startup.expo.domain.participant.service;
+
+import team.startup.expo.domain.participant.presentation.dto.response.GetParticipantInfoResponseDto;
+import team.startup.expo.domain.trainee.ParticipationType;
+
+import java.util.List;
+
+public interface GetParticipantInfoService {
+    List<GetParticipantInfoResponseDto> execute(String expoId, ParticipationType type);
+}

--- a/src/main/java/team/startup/expo/domain/participant/service/impl/GetParticipantInfoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/participant/service/impl/GetParticipantInfoServiceImpl.java
@@ -1,0 +1,38 @@
+package team.startup.expo.domain.participant.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import team.startup.expo.domain.expo.Expo;
+import team.startup.expo.domain.expo.exception.NotFoundExpoException;
+import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.participant.presentation.dto.response.GetParticipantInfoResponseDto;
+import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.participant.service.GetParticipantInfoService;
+import team.startup.expo.domain.trainee.ParticipationType;
+import team.startup.expo.global.annotation.ReadOnlyTransactionService;
+
+import java.util.List;
+
+@ReadOnlyTransactionService
+@RequiredArgsConstructor
+public class GetParticipantInfoServiceImpl implements GetParticipantInfoService {
+
+    private final ParticipantRepository participantRepository;
+    private final ExpoRepository expoRepository;
+
+    public List<GetParticipantInfoResponseDto> execute(String expoId, ParticipationType type) {
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(NotFoundExpoException::new);
+
+        return participantRepository.findByExpoAndParticipationType(expo, type).stream()
+                .map(expoParticipant -> GetParticipantInfoResponseDto.builder()
+                        .id(expoParticipant.getId())
+                        .name(expoParticipant.getName())
+                        .phoneNumber(expoParticipant.getPhoneNumber())
+                        .affiliation(expoParticipant.getAffiliation())
+                        .informationStatus(expoParticipant.getInformationStatus())
+                        .position(expoParticipant.getPosition())
+                        .build()
+                ).toList();
+
+    }
+}

--- a/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
@@ -79,6 +79,9 @@ public class SecurityConfig {
                                 // trainee
                                 .requestMatchers(HttpMethod.GET, "/trainee").hasAnyAuthority(Authority.ROLE_ADMIN.name())
 
+                                // participant
+                                .requestMatchers(HttpMethod.GET, "/participant/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
+
                                 // training
                                 .requestMatchers(HttpMethod.GET, "/training/{trainingPro_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
                                 .requestMatchers(HttpMethod.POST, "/training/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())


### PR DESCRIPTION
## 💡 배경 및 개요

사전 신청과 현장 참가자의 정보를 출력하는 api를 추가하였습니다

Resolves: #105 

## 📃 작업내용

사전 신청과 현장 참가자를 ParticipationType으로 나누어 사전 신청과 현장 신청을 나누어 정보를 가져올 수 있도록 하였습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타