### PR TITLE
🔀 :: 일반 참가자 및 연수자 중복 방지

### DIFF
--- a/src/main/java/team/startup/expo/domain/form/exception/AlreadyApplicationUserException.java
+++ b/src/main/java/team/startup/expo/domain/form/exception/AlreadyApplicationUserException.java
@@ -1,0 +1,10 @@
+package team.startup.expo.domain.form.exception;
+
+import team.startup.expo.global.exception.ErrorCode;
+import team.startup.expo.global.exception.GlobalException;
+
+public class AlreadyApplicationUserException extends GlobalException {
+    public AlreadyApplicationUserException() {
+        super(ErrorCode.ALREADY_APPLICATION_USER);
+    }
+}

--- a/src/main/java/team/startup/expo/domain/form/service/impl/PreApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/PreApplicationForParticipantServiceImpl.java
@@ -5,11 +5,13 @@ import team.startup.expo.domain.admin.Authority;
 import team.startup.expo.domain.expo.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.form.exception.AlreadyApplicationUserException;
 import team.startup.expo.domain.form.presentation.dto.request.PreApplicationForParticipantRequestDto;
 import team.startup.expo.domain.form.service.PreApplicationForParticipantService;
 import team.startup.expo.domain.participant.ExpoParticipant;
 import team.startup.expo.domain.participant.repository.ParticipantRepository;
 import team.startup.expo.domain.trainee.ParticipationType;
+import team.startup.expo.domain.trainee.repository.TraineeRepository;
 import team.startup.expo.global.annotation.TransactionService;
 
 @TransactionService
@@ -18,10 +20,14 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
 
     private final ExpoRepository expoRepository;
     private final ParticipantRepository participantRepository;
+    private final TraineeRepository traineeRepository;
 
     public void execute(String expoId, PreApplicationForParticipantRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
+
+        if (participantRepository.existsByPhoneNumber(dto.getPhoneNumber()) || traineeRepository.existsByPhoneNumber(dto.getPhoneNumber()))
+            throw new AlreadyApplicationUserException();
 
         saveParticipant(expo, dto);
     }

--- a/src/main/java/team/startup/expo/domain/form/service/impl/PreApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/PreApplicationForTraineeServiceImpl.java
@@ -5,8 +5,10 @@ import team.startup.expo.domain.admin.Authority;
 import team.startup.expo.domain.expo.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.form.exception.AlreadyApplicationUserException;
 import team.startup.expo.domain.form.presentation.dto.request.PreApplicationForTraineeRequestDto;
 import team.startup.expo.domain.form.service.PreApplicationForTraineeService;
+import team.startup.expo.domain.participant.repository.ParticipantRepository;
 import team.startup.expo.domain.trainee.ParticipationType;
 import team.startup.expo.domain.trainee.Trainee;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
@@ -18,10 +20,15 @@ public class PreApplicationForTraineeServiceImpl implements PreApplicationForTra
 
     private final TraineeRepository traineeRepository;
     private final ExpoRepository expoRepository;
+    private final ParticipantRepository participantRepository;
+
 
     public void execute(String expoId, PreApplicationForTraineeRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
+
+        if (participantRepository.existsByPhoneNumber(dto.getPhoneNumber()) || traineeRepository.existsByPhoneNumber(dto.getPhoneNumber()))
+            throw new AlreadyApplicationUserException();
 
         saveTrainee(dto, expo);
     }

--- a/src/main/java/team/startup/expo/domain/participant/ExpoParticipant.java
+++ b/src/main/java/team/startup/expo/domain/participant/ExpoParticipant.java
@@ -23,7 +23,7 @@ public class ExpoParticipant {
     @Column(nullable = false, columnDefinition = "VARCHAR(10)")
     private String name;
 
-    @Column(nullable = false, columnDefinition = "VARCHAR(15)")
+    @Column(nullable = false, unique = true, columnDefinition = "VARCHAR(15)")
     private String phoneNumber;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/team/startup/expo/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/ParticipantRepository.java
@@ -12,4 +12,5 @@ public interface ParticipantRepository extends JpaRepository<ExpoParticipant, Lo
     Optional<ExpoParticipant> findByPhoneNumber(String phoneNumber);
     void deleteByExpo(Expo expo);
     List<ExpoParticipant> findByExpoAndParticipationType(Expo expo, ParticipationType participationType);
+    Boolean existsByPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/team/startup/expo/domain/trainee/Trainee.java
+++ b/src/main/java/team/startup/expo/domain/trainee/Trainee.java
@@ -25,7 +25,7 @@ public class Trainee {
     @Column(nullable = false, columnDefinition = "TINYINT(1)")
     private Boolean laptopStatus;
 
-    @Column(nullable = false, columnDefinition = "VARCHAR(15)")
+    @Column(nullable = false, unique = true, columnDefinition = "VARCHAR(15)")
     private String phoneNumber;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/team/startup/expo/domain/trainee/repository/TraineeRepository.java
+++ b/src/main/java/team/startup/expo/domain/trainee/repository/TraineeRepository.java
@@ -11,4 +11,5 @@ public interface TraineeRepository extends JpaRepository<Trainee, Long> {
     Optional<Trainee> findByPhoneNumber(String phoneNumber);
     List<Trainee> findByExpo(Expo expo);
     void deleteByExpo(Expo expo);
+    Boolean existsByPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/team/startup/expo/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/expo/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(409, "이미 존재하는 이메일입니다."),
     NOT_MATCH_ADMIN(403, "관리자가 일치하지 않습니다."),
     ALREADY_LEAVE_PROGRAM_USER(400, "이미 프로그램을 퇴실한 유저입니다."),
+    ALREADY_APPLICATION_USER(409, "이미 신청한 유저입니다."),
 
     // auth
     NOT_MATCH_PASSWORD(400, "비밀번호가 일치하지 않습니다."),


### PR DESCRIPTION
## 💡 배경 및 개요

만약 연수자와 일반 참가자의 동일인물이 존재할시 로직의 오류가 생겨 이를 방지하기 위해 if문을 추가하였습니다

Resolves: #109 

## 📃 작업내용

* 연수자 및 일반 참가자 중복 데이터 방지 if문 추가

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타