### PR TITLE
🔀 :: 외래키 제약 조건 로직 수정

### DIFF
--- a/src/main/java/team/startup/expo/domain/expo/service/impl/DeleteExpoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/impl/DeleteExpoServiceImpl.java
@@ -9,10 +9,17 @@ import team.startup.expo.domain.expo.exception.NotMatchAdminException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.expo.service.DeleteExpoService;
 import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.standard.StandardProgram;
 import team.startup.expo.domain.standard.repository.StandardProgramRepository;
+import team.startup.expo.domain.standard.repository.StandardProgramUserRepository;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
+import team.startup.expo.domain.training.TrainingProgram;
+import team.startup.expo.domain.training.TrainingProgramUser;
 import team.startup.expo.domain.training.repository.TrainingProgramRepository;
+import team.startup.expo.domain.training.repository.TrainingProgramUserRepository;
 import team.startup.expo.global.annotation.TransactionService;
+
+import java.util.List;
 
 @TransactionService
 @RequiredArgsConstructor
@@ -20,6 +27,8 @@ public class DeleteExpoServiceImpl implements DeleteExpoService {
 
     private final ExpoRepository expoRepository;
     private final StandardProgramRepository standardProgramRepository;
+    private final StandardProgramUserRepository standardProgramUserRepository;
+    private final TrainingProgramUserRepository trainingProgramUserRepository;
     private final ParticipantRepository participantRepository;
     private final TraineeRepository traineeRepository;
     private final TrainingProgramRepository trainingProgramRepository;
@@ -31,9 +40,17 @@ public class DeleteExpoServiceImpl implements DeleteExpoService {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
-        if (expo.getAdmin() != admin)
+        if (expo.getAdmin() != admin) {
             throw new NotMatchAdminException();
+        }
 
+        List<TrainingProgram> trainingPrograms = trainingProgramRepository.findByExpo(expo);
+
+        trainingPrograms.forEach(trainingProgramUserRepository::deleteByTrainingProgram);
+
+        List<StandardProgram> standardPrograms = standardProgramRepository.findByExpo(expo);
+
+        standardPrograms.forEach(standardProgramUserRepository::deleteByStandardProgram);
 
         standardProgramRepository.deleteByExpo(expo);
         trainingProgramRepository.deleteByExpo(expo);


### PR DESCRIPTION
## 💡 배경 및 개요

연수 프로그램 신청 연수자와 일반 프로그램의 일반 관람객을 삭제하지 않아 외래키 제약 조건이 발생하여 로직을 수정하였습니다

Resolves: #119 

## 📃 작업내용

* trainingProgramUser, standardProgramUser를 forEach를 사용하여 삭제 로직 추가

## 🙋‍♂️ 리뷰노트

급하게 수정하느라 나중에 리팩토링 진행하겠습니다

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타