### PR TITLE
update :: 조건문 수정

### DIFF
--- a/src/main/java/team/startup/expo/domain/form/service/impl/PreApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/PreApplicationForParticipantServiceImpl.java
@@ -26,7 +26,7 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
-        if (participantRepository.existsByPhoneNumber(dto.getPhoneNumber()) || traineeRepository.existsByPhoneNumber(dto.getPhoneNumber()))
+        if (participantRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo) || traineeRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo))
             throw new AlreadyApplicationUserException();
 
         saveParticipant(expo, dto);

--- a/src/main/java/team/startup/expo/domain/form/service/impl/PreApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/PreApplicationForTraineeServiceImpl.java
@@ -27,7 +27,7 @@ public class PreApplicationForTraineeServiceImpl implements PreApplicationForTra
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
-        if (participantRepository.existsByPhoneNumber(dto.getPhoneNumber()) || traineeRepository.existsByPhoneNumber(dto.getPhoneNumber()))
+        if (participantRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo) || traineeRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo))
             throw new AlreadyApplicationUserException();
 
         saveTrainee(dto, expo);

--- a/src/main/java/team/startup/expo/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/ParticipantRepository.java
@@ -12,5 +12,5 @@ public interface ParticipantRepository extends JpaRepository<ExpoParticipant, Lo
     Optional<ExpoParticipant> findByPhoneNumber(String phoneNumber);
     void deleteByExpo(Expo expo);
     List<ExpoParticipant> findByExpoAndParticipationType(Expo expo, ParticipationType participationType);
-    Boolean existsByPhoneNumber(String phoneNumber);
+    Boolean existsByPhoneNumberAndExpo(String phoneNumber, Expo expo);
 }

--- a/src/main/java/team/startup/expo/domain/trainee/repository/TraineeRepository.java
+++ b/src/main/java/team/startup/expo/domain/trainee/repository/TraineeRepository.java
@@ -11,6 +11,6 @@ public interface TraineeRepository extends JpaRepository<Trainee, Long> {
     Optional<Trainee> findByPhoneNumber(String phoneNumber);
     List<Trainee> findByExpo(Expo expo);
     void deleteByExpo(Expo expo);
-    Boolean existsByPhoneNumber(String phoneNumber);
+    Boolean existsByPhoneNumberAndExpo(String phoneNumber, Expo expo);
     Optional<Trainee> findByTrainingId(String trainingId);
 }


### PR DESCRIPTION
## 💡 배경 및 개요

현재 로직은 여러 박람회에서 전화번호가 겹친다면 신청을 못 하는 방식이였지만 최종적으로는 박람회별로의 중복으로 신청을 하지 못 하게 조건문을 변경하였습니다

Resolves: #121 

## 📃 작업내용

박람회별로의 중복으로 신청을 하지 못 하게 조건문을 변경하였습니다.
* existsByPhoneNumber -> existsByPhoneNumberAndExpo 변경

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타