### PR TITLE
🔀 :: 박람회 다중 신청에 대한 api 수정

### DIFF
--- a/src/main/java/team/startup/expo/domain/attendance/presentation/AttendanceController.java
+++ b/src/main/java/team/startup/expo/domain/attendance/presentation/AttendanceController.java
@@ -39,9 +39,9 @@ public class AttendanceController {
         return ResponseEntity.ok().build();
     }
 
-    @PatchMapping
-    public ResponseEntity<PreEnterScanQrCodeResponseDto> preEnterScanQrCode(@RequestBody @Valid PreEnterScanQrCodeRequestDto dto) {
-        PreEnterScanQrCodeResponseDto response = preEnterScanQrCodeService.execute(dto);
+    @PatchMapping("/{expo_id}")
+    public ResponseEntity<PreEnterScanQrCodeResponseDto> preEnterScanQrCode(@PathVariable("expo_id") String expoId, @RequestBody @Valid PreEnterScanQrCodeRequestDto dto) {
+        PreEnterScanQrCodeResponseDto response = preEnterScanQrCodeService.execute(expoId, dto);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/team/startup/expo/domain/attendance/service/PreEnterScanQrCodeService.java
+++ b/src/main/java/team/startup/expo/domain/attendance/service/PreEnterScanQrCodeService.java
@@ -4,5 +4,5 @@ import team.startup.expo.domain.attendance.presentation.dto.request.PreEnterScan
 import team.startup.expo.domain.attendance.presentation.dto.response.PreEnterScanQrCodeResponseDto;
 
 public interface PreEnterScanQrCodeService {
-    PreEnterScanQrCodeResponseDto execute(PreEnterScanQrCodeRequestDto dto);
+    PreEnterScanQrCodeResponseDto execute(String expoId, PreEnterScanQrCodeRequestDto dto);
 }

--- a/src/main/java/team/startup/expo/domain/participant/repository/ParticipantRepository.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/ParticipantRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ParticipantRepository extends JpaRepository<ExpoParticipant, Long> {
-    Optional<ExpoParticipant> findByPhoneNumber(String phoneNumber);
+    Optional<ExpoParticipant> findByPhoneNumberAndExpo(String phoneNumber, Expo expo);
     void deleteByExpo(Expo expo);
     List<ExpoParticipant> findByExpoAndParticipationType(Expo expo, ParticipationType participationType);
     Boolean existsByPhoneNumberAndExpo(String phoneNumber, Expo expo);

--- a/src/main/java/team/startup/expo/domain/sms/presentation/SmsController.java
+++ b/src/main/java/team/startup/expo/domain/sms/presentation/SmsController.java
@@ -36,9 +36,9 @@ public class SmsController {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @PostMapping("/qr")
-    public ResponseEntity<SingleMessageSentResponse> sendQr(@RequestBody SendQrRequestDto dto) {
-        SingleMessageSentResponse response = sendQrService.execute(dto);
+    @PostMapping("/qr/{expo_id}")
+    public ResponseEntity<SingleMessageSentResponse> sendQr(@PathVariable("expo_id") String expoId, @RequestBody SendQrRequestDto dto) {
+        SingleMessageSentResponse response = sendQrService.execute(expoId, dto);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/team/startup/expo/domain/sms/service/SendQrService.java
+++ b/src/main/java/team/startup/expo/domain/sms/service/SendQrService.java
@@ -4,5 +4,5 @@ import net.nurigo.sdk.message.response.SingleMessageSentResponse;
 import team.startup.expo.domain.sms.presentation.dto.request.SendQrRequestDto;
 
 public interface SendQrService {
-    SingleMessageSentResponse execute(SendQrRequestDto dto);
+    SingleMessageSentResponse execute(String expoId, SendQrRequestDto dto);
 }

--- a/src/main/java/team/startup/expo/domain/trainee/repository/TraineeRepository.java
+++ b/src/main/java/team/startup/expo/domain/trainee/repository/TraineeRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TraineeRepository extends JpaRepository<Trainee, Long> {
-    Optional<Trainee> findByPhoneNumber(String phoneNumber);
+    Optional<Trainee> findByPhoneNumberAndExpo(String phoneNumber, Expo expo);
     List<Trainee> findByExpo(Expo expo);
     void deleteByExpo(Expo expo);
     Boolean existsByPhoneNumberAndExpo(String phoneNumber, Expo expo);

--- a/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
                                 // sms
                                 .requestMatchers(HttpMethod.POST, "/sms").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/sms").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/sms/qr").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/sms/qr/{expo_id}").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/sms/message/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
 
                                 // admin
@@ -114,7 +114,7 @@ public class SecurityConfig {
                                 // attendance
                                 .requestMatchers(HttpMethod.PATCH, "/attendance/training/{trainingPro_id}").permitAll()
                                 .requestMatchers(HttpMethod.PATCH, "/attendance/standard/{standardPro_id}").permitAll()
-                                .requestMatchers(HttpMethod.PATCH, "/attendance").permitAll()
+                                .requestMatchers(HttpMethod.PATCH, "/attendance/{expo_id}").permitAll()
 
                                 // form
                                 .requestMatchers(HttpMethod.POST, "/form/{expo_id}").permitAll()


### PR DESCRIPTION
## 💡 배경 및 개요

박람회 다중 신청이 가능하게 되어 api에 존재하는 쿼리 메서드를 변경하였습니다

Resolves: #127 

## 📃 작업내용

* findByPhoneNumber -> findByPhoneNumberAndExpo
* Path로 ExpoId 추가 요청

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타