### PR TITLE
🔀 :: 폼과 동적폼 생성

### DIFF
--- a/src/main/java/team/startup/expo/domain/form/entity/DynamicForm.java
+++ b/src/main/java/team/startup/expo/domain/form/entity/DynamicForm.java
@@ -29,7 +29,7 @@ public class DynamicForm {
     @Column(nullable = false)
     private FormType formType;
 
-    @JoinColumn(name = "expo_id")
+    @JoinColumn(name = "form_id")
     @ManyToOne
-    private Expo expo;
+    private Form form;
 }

--- a/src/main/java/team/startup/expo/domain/form/exception/AlreadyExistFormException.java
+++ b/src/main/java/team/startup/expo/domain/form/exception/AlreadyExistFormException.java
@@ -1,0 +1,10 @@
+package team.startup.expo.domain.form.exception;
+
+import team.startup.expo.global.exception.ErrorCode;
+import team.startup.expo.global.exception.GlobalException;
+
+public class AlreadyExistFormException extends GlobalException {
+    public AlreadyExistFormException() {
+        super(ErrorCode.ALREADY_EXIST_FORM);
+    }
+}

--- a/src/main/java/team/startup/expo/domain/form/presentation/FormController.java
+++ b/src/main/java/team/startup/expo/domain/form/presentation/FormController.java
@@ -1,0 +1,23 @@
+package team.startup.expo.domain.form.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import team.startup.expo.domain.form.presentation.dto.request.CreateFormRequestDto;
+import team.startup.expo.domain.form.service.CreateFormService;
+
+@RestController
+@RequestMapping("/form")
+@RequiredArgsConstructor
+public class FormController {
+
+    private final CreateFormService createFormService;
+
+    @PostMapping("/{expo_id}")
+    public ResponseEntity<Void> createForm(@PathVariable("expo_id") String expoId, @RequestBody @Valid CreateFormRequestDto dto) {
+        createFormService.execute(expoId, dto);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/team/startup/expo/domain/form/presentation/dto/request/CreateFormRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/form/presentation/dto/request/CreateFormRequestDto.java
@@ -1,0 +1,35 @@
+package team.startup.expo.domain.form.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.startup.expo.domain.form.entity.FormType;
+import team.startup.expo.domain.form.entity.ParticipationType;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CreateFormRequestDto {
+    @NotNull
+    private String informationImage;
+
+    @NotNull
+    private ParticipationType participantType;
+
+    @NotNull
+    private List<CreateDynamicFormRequestDto> dynamicForm;
+
+    @Getter
+    @NoArgsConstructor
+    public static class CreateDynamicFormRequestDto {
+        @NotNull
+        private String title;
+
+        @NotNull
+        private FormType formType;
+
+        @NotNull
+        private String jsonData;
+    }
+}

--- a/src/main/java/team/startup/expo/domain/form/repository/DynamicFormRepository.java
+++ b/src/main/java/team/startup/expo/domain/form/repository/DynamicFormRepository.java
@@ -1,0 +1,7 @@
+package team.startup.expo.domain.form.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.startup.expo.domain.form.entity.DynamicForm;
+
+public interface DynamicFormRepository extends JpaRepository<DynamicForm, Long> {
+}

--- a/src/main/java/team/startup/expo/domain/form/repository/FormRepository.java
+++ b/src/main/java/team/startup/expo/domain/form/repository/FormRepository.java
@@ -1,0 +1,13 @@
+package team.startup.expo.domain.form.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.form.entity.Form;
+import team.startup.expo.domain.form.entity.ParticipationType;
+
+import java.util.Optional;
+
+public interface FormRepository extends JpaRepository<Form, Long> {
+    Optional<Form> findByExpo(Expo expo);
+    Boolean existsByExpoAndParticipationType(Expo expo, ParticipationType participationType);
+}

--- a/src/main/java/team/startup/expo/domain/form/service/CreateFormService.java
+++ b/src/main/java/team/startup/expo/domain/form/service/CreateFormService.java
@@ -1,0 +1,7 @@
+package team.startup.expo.domain.form.service;
+
+import team.startup.expo.domain.form.presentation.dto.request.CreateFormRequestDto;
+
+public interface CreateFormService {
+    void execute(String expoId, CreateFormRequestDto createFormRequestDto);
+}

--- a/src/main/java/team/startup/expo/domain/form/service/impl/CreateFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/CreateFormServiceImpl.java
@@ -1,0 +1,56 @@
+package team.startup.expo.domain.form.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.expo.exception.NotFoundExpoException;
+import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.form.entity.DynamicForm;
+import team.startup.expo.domain.form.entity.Form;
+import team.startup.expo.domain.form.exception.AlreadyExistFormException;
+import team.startup.expo.domain.form.presentation.dto.request.CreateFormRequestDto;
+import team.startup.expo.domain.form.repository.DynamicFormRepository;
+import team.startup.expo.domain.form.repository.FormRepository;
+import team.startup.expo.domain.form.service.CreateFormService;
+import team.startup.expo.global.annotation.TransactionService;
+
+@TransactionService
+@RequiredArgsConstructor
+public class CreateFormServiceImpl implements CreateFormService {
+
+    private final FormRepository formRepository;
+    private final DynamicFormRepository dynamicFormRepository;
+    private final ExpoRepository expoRepository;
+
+    public void execute(String expoId, CreateFormRequestDto createFormRequestDto) {
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(NotFoundExpoException::new);
+
+        if (formRepository.existsByExpoAndParticipationType(expo, createFormRequestDto.getParticipantType()))
+            throw new AlreadyExistFormException();
+
+        Form form = saveForm(createFormRequestDto, expo);
+
+        createFormRequestDto.getDynamicForm().forEach(dynamicForm -> {saveDynamicForm(dynamicForm, form);});
+    }
+
+    private Form saveForm(CreateFormRequestDto createFormRequestDto, Expo expo) {
+        Form form = Form.builder()
+                .informationImage(createFormRequestDto.getInformationImage())
+                .participationType(createFormRequestDto.getParticipantType())
+                .expo(expo)
+                .build();
+
+        return formRepository.save(form);
+    }
+
+    private void saveDynamicForm(CreateFormRequestDto.CreateDynamicFormRequestDto dynamicFormRequestDto, Form form) {
+        DynamicForm dynamicForm = DynamicForm.builder()
+                .title(dynamicFormRequestDto.getTitle())
+                .jsonData(dynamicFormRequestDto.getJsonData())
+                .formType(dynamicFormRequestDto.getFormType())
+                .form(form)
+                .build();
+
+        dynamicFormRepository.save(dynamicForm);
+    }
+}

--- a/src/main/java/team/startup/expo/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/expo/global/exception/ErrorCode.java
@@ -56,6 +56,9 @@ public enum ErrorCode {
     // trainee
     NOT_FOUND_TRAINEE(404, "연수자를 찾지 못 했습니다."),
 
+    // form
+    ALREADY_EXIST_FORM(409, "이미 폼이 존재합니다."),
+
     // server
     INTERNAL_SERVER_ERROR(500, "예기치 못한 서버 에러");
 

--- a/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
@@ -116,11 +116,14 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.PATCH, "/attendance/standard/{standardPro_id}").permitAll()
                                 .requestMatchers(HttpMethod.PATCH, "/attendance/{expo_id}").permitAll()
 
+                                // application
+                                .requestMatchers(HttpMethod.POST, "/application/{expo_id}").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/application/pre-standard/{expo_id}").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/application/field/{expo_id}").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/application/field/standard/{expo_id}").permitAll()
+
                                 // form
-                                .requestMatchers(HttpMethod.POST, "/form/{expo_id}").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/form/pre-standard/{expo_id}").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/form/field/{expo_id}").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/form/field/standard/{expo_id}").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/form/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
 
                                 //image
                                 .requestMatchers(HttpMethod.POST, "/image").authenticated()


### PR DESCRIPTION
## 💡 배경 및 개요

폼과 동적폼을 생성할 수 있는 api를 추가하였습니다

Resolves: #142 

## 📃 작업내용

* CreateForm api 추가

## 🙋‍♂️ 리뷰노트

<img width="686" alt="스크린샷 2025-01-14 오전 1 31 42" src="https://github.com/user-attachments/assets/040e124d-6d6f-45d5-9ecc-720212afcadd" />

위 이미지는 폼 json의 형식 예시입니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타