### PR TITLE
🔀 :: 박람회 생성/수정 및 연수/일반 프로그램 api 결합

### DIFF
--- a/src/main/java/team/startup/expo/domain/expo/presentation/dto/request/GenerateExpoRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/expo/presentation/dto/request/GenerateExpoRequestDto.java
@@ -5,8 +5,11 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team.startup.expo.domain.standard.presentation.dto.request.AddStandardProRequestDto;
+import team.startup.expo.domain.training.presentation.dto.request.AddTrainingProRequestDto;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -37,4 +40,10 @@ public class GenerateExpoRequestDto {
 
     @NotNull
     private Float y;
+
+    @NotNull
+    private List<AddStandardProRequestDto> addStandardProRequestDto;
+
+    @NotNull
+    private List<AddTrainingProRequestDto> addTrainingProRequestDto;
 }

--- a/src/main/java/team/startup/expo/domain/expo/presentation/dto/request/UpdateExpoRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/expo/presentation/dto/request/UpdateExpoRequestDto.java
@@ -6,8 +6,14 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.standard.presentation.dto.request.AddStandardProRequestDto;
+import team.startup.expo.domain.standard.presentation.dto.request.UpdateStandardProRequestDto;
+import team.startup.expo.domain.training.presentation.dto.request.AddTrainingProRequestDto;
+import team.startup.expo.domain.training.presentation.dto.request.UpdateTrainingProRequestDto;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -21,11 +27,11 @@ public class UpdateExpoRequestDto {
 
     @NotNull
     @JsonFormat(pattern = "yyyy-MM-dd")
-    private LocalDateTime startedDay;
+    private LocalDate startedDay;
 
     @NotNull
     @JsonFormat(pattern = "yyyy-MM-dd")
-    private LocalDateTime finishedDay;
+    private LocalDate finishedDay;
 
     @NotNull
     private String location;
@@ -38,6 +44,12 @@ public class UpdateExpoRequestDto {
 
     @NotNull
     private Float y;
+
+    @NotNull
+    private List<UpdateStandardProRequestDto> updateStandardProRequestDto;
+
+    @NotNull
+    private List<UpdateTrainingProRequestDto> updateTrainingProRequestDto;
 
     public Expo toEntity(Expo expo) {
         return Expo.builder()

--- a/src/main/java/team/startup/expo/domain/expo/service/impl/GenerateExpoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/impl/GenerateExpoServiceImpl.java
@@ -8,8 +8,16 @@ import team.startup.expo.domain.expo.presentation.dto.request.GenerateExpoReques
 import team.startup.expo.domain.expo.presentation.dto.response.GenerateExpoResponseDto;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.expo.service.GenerateExpoService;
+import team.startup.expo.domain.standard.entity.StandardProgram;
+import team.startup.expo.domain.standard.presentation.dto.request.AddStandardProRequestDto;
+import team.startup.expo.domain.standard.repository.StandardProgramRepository;
+import team.startup.expo.domain.training.entity.TrainingProgram;
+import team.startup.expo.domain.training.presentation.dto.request.AddTrainingProRequestDto;
+import team.startup.expo.domain.training.repository.TrainingProgramRepository;
 import team.startup.expo.global.annotation.TransactionService;
 import team.startup.expo.global.common.ulid.ULIDGenerator;
+
+import java.util.List;
 
 @TransactionService
 @RequiredArgsConstructor
@@ -17,18 +25,23 @@ public class GenerateExpoServiceImpl implements GenerateExpoService {
 
     private final ExpoRepository expoRepository;
     private final UserUtil userUtil;
+    private final StandardProgramRepository standardProgramRepository;
+    private final TrainingProgramRepository trainingProgramRepository;
 
     public GenerateExpoResponseDto execute(GenerateExpoRequestDto dto) {
         Admin admin = userUtil.getCurrentUser();
 
-        String expoId = saveExpo(dto, admin);
+        Expo expo = saveExpo(dto, admin);
+
+        dto.getAddStandardProRequestDto().forEach(addStandardProRequestDto -> {saveStandardPro(addStandardProRequestDto, expo);});
+        dto.getAddTrainingProRequestDto().forEach(addTrainingProRequestDto -> {saveTrainingPro(addTrainingProRequestDto, expo);});
 
         return GenerateExpoResponseDto.builder()
-                .expoId(expoId)
+                .expoId(expo.getId())
                 .build();
     }
 
-    private String saveExpo(GenerateExpoRequestDto dto, Admin admin) {
+    private Expo saveExpo(GenerateExpoRequestDto dto, Admin admin) {
         Expo expo = Expo.builder()
                 .id(ULIDGenerator.generateULID())
                 .title(dto.getTitle())
@@ -44,6 +57,29 @@ public class GenerateExpoServiceImpl implements GenerateExpoService {
 
         expoRepository.save(expo);
 
-        return expo.getId();
+        return expo;
+    }
+
+    private void saveStandardPro(AddStandardProRequestDto dto, Expo expo) {
+        StandardProgram standardProgram = StandardProgram.builder()
+                .title(dto.getTitle())
+                .startedAt(String.valueOf(dto.getStartedAt()))
+                .endedAt(String.valueOf(dto.getEndedAt()))
+                .expo(expo)
+                .build();
+
+        standardProgramRepository.save(standardProgram);
+    }
+
+    private void saveTrainingPro(AddTrainingProRequestDto dto, Expo expo) {
+        TrainingProgram trainingProgram = TrainingProgram.builder()
+                .title(dto.getTitle())
+                .startedAt(String.valueOf(dto.getStartedAt()))
+                .endedAt(String.valueOf(dto.getEndedAt()))
+                .category(dto.getCategory())
+                .expo(expo)
+                .build();
+
+        trainingProgramRepository.save(trainingProgram);
     }
 }

--- a/src/main/java/team/startup/expo/domain/expo/service/impl/UpdateExpoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/impl/UpdateExpoServiceImpl.java
@@ -9,6 +9,14 @@ import team.startup.expo.domain.expo.exception.NotMatchAdminException;
 import team.startup.expo.domain.expo.presentation.dto.request.UpdateExpoRequestDto;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.expo.service.UpdateExpoService;
+import team.startup.expo.domain.standard.entity.StandardProgram;
+import team.startup.expo.domain.standard.presentation.dto.request.AddStandardProRequestDto;
+import team.startup.expo.domain.standard.presentation.dto.request.UpdateStandardProRequestDto;
+import team.startup.expo.domain.standard.repository.StandardProgramRepository;
+import team.startup.expo.domain.training.entity.TrainingProgram;
+import team.startup.expo.domain.training.presentation.dto.request.AddTrainingProRequestDto;
+import team.startup.expo.domain.training.presentation.dto.request.UpdateTrainingProRequestDto;
+import team.startup.expo.domain.training.repository.TrainingProgramRepository;
 import team.startup.expo.global.annotation.TransactionService;
 
 @TransactionService
@@ -17,6 +25,8 @@ public class UpdateExpoServiceImpl implements UpdateExpoService {
 
     private final ExpoRepository expoRepository;
     private final UserUtil userUtil;
+    private final StandardProgramRepository standardProgramRepository;
+    private final TrainingProgramRepository trainingProgramRepository;
 
     public void execute(String expoId, UpdateExpoRequestDto dto) {
         Admin admin = userUtil.getCurrentUser();
@@ -27,6 +37,34 @@ public class UpdateExpoServiceImpl implements UpdateExpoService {
         if (expo.getAdmin() != admin)
             throw new NotMatchAdminException();
 
+        dto.getUpdateStandardProRequestDto().forEach(updateStandardProRequestDto -> {saveStandardPro(updateStandardProRequestDto, expo);});
+        dto.getUpdateTrainingProRequestDto().forEach(updateTrainingProRequestDto -> {saveTrainingPro(updateTrainingProRequestDto, expo);});
+
         expoRepository.save(dto.toEntity(expo));
+    }
+
+    private void saveStandardPro(UpdateStandardProRequestDto dto, Expo expo) {
+        StandardProgram standardProgram = StandardProgram.builder()
+                .id(dto.getId())
+                .title(dto.getTitle())
+                .startedAt(String.valueOf(dto.getStartedAt()))
+                .endedAt(String.valueOf(dto.getEndedAt()))
+                .expo(expo)
+                .build();
+
+        standardProgramRepository.save(standardProgram);
+    }
+
+    private void saveTrainingPro(UpdateTrainingProRequestDto dto, Expo expo) {
+        TrainingProgram trainingProgram = TrainingProgram.builder()
+                .id(dto.getId())
+                .title(dto.getTitle())
+                .startedAt(String.valueOf(dto.getStartedAt()))
+                .endedAt(String.valueOf(dto.getEndedAt()))
+                .category(dto.getCategory())
+                .expo(expo)
+                .build();
+
+        trainingProgramRepository.save(trainingProgram);
     }
 }

--- a/src/main/java/team/startup/expo/domain/standard/presentation/dto/request/UpdateStandardProRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/standard/presentation/dto/request/UpdateStandardProRequestDto.java
@@ -12,6 +12,9 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class UpdateStandardProRequestDto {
     @NotNull
+    private Long id;
+
+    @NotNull
     private String title;
 
     @NotNull

--- a/src/main/java/team/startup/expo/domain/training/presentation/dto/request/UpdateTrainingProRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/training/presentation/dto/request/UpdateTrainingProRequestDto.java
@@ -12,6 +12,8 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor
 public class UpdateTrainingProRequestDto {
+    @NotNull
+    private Long id;
 
     @NotNull
     private String title;


### PR DESCRIPTION
## 💡 배경 및 개요

박람회를 생성/수정을 하는 api에 연수/일반 프로그램을 추가하고 수정하는 api를 각각 로직에 더하여 한번에 처리하도록 수정하였습니다

Resolves: #{이슈번호}

## 📃 작업내용

* GenerateExpo api + Add(Standard/Training)Program api
* UpdateExpo api + Update(Standard/Training)Program api

## 🙋‍♂️ 리뷰노트

아직 연수/일반 프로그램 추가 및 수정 api를 제거하지 않아 나중에 제거해야됩니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타