### PR TITLE
🔀 :: 박람회 신청과 Qr 발송 이벤트 처리

### DIFF
--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
@@ -1,6 +1,7 @@
 package team.startup.expo.domain.application.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import team.startup.expo.domain.admin.entity.Authority;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
@@ -10,6 +11,8 @@ import team.startup.expo.domain.application.presentation.dto.request.Application
 import team.startup.expo.domain.application.service.FieldApplicationForParticipantService;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.sms.event.SendQrEvent;
+import team.startup.expo.domain.sms.event.handler.SendQrEventHandler;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
 import team.startup.expo.global.annotation.TransactionService;
@@ -21,6 +24,7 @@ public class FieldApplicationForParticipantServiceImpl implements FieldApplicati
     private final ExpoRepository expoRepository;
     private final ParticipantRepository participantRepository;
     private final TraineeRepository traineeRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public void execute(String expoId, ApplicationForParticipantRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
@@ -30,6 +34,8 @@ public class FieldApplicationForParticipantServiceImpl implements FieldApplicati
             throw new AlreadyApplicationUserException();
 
         saveParticipant(expo, dto);
+
+        applicationEventPublisher.publishEvent(new SendQrEvent(expoId, dto.getPhoneNumber(), Authority.ROLE_STANDARD));
     }
 
     private void saveParticipant(Expo expo, ApplicationForParticipantRequestDto dto) {

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForTraineeServiceImpl.java
@@ -1,6 +1,7 @@
 package team.startup.expo.domain.application.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import team.startup.expo.domain.admin.entity.Authority;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
@@ -9,6 +10,7 @@ import team.startup.expo.domain.application.exception.AlreadyApplicationUserExce
 import team.startup.expo.domain.application.presentation.dto.request.ApplicationForTraineeRequestDto;
 import team.startup.expo.domain.application.service.FieldApplicationForTraineeService;
 import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.sms.event.SendQrEvent;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.domain.trainee.entity.Trainee;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
@@ -21,6 +23,7 @@ public class FieldApplicationForTraineeServiceImpl implements FieldApplicationFo
     private final TraineeRepository traineeRepository;
     private final ExpoRepository expoRepository;
     private final ParticipantRepository participantRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public void execute(String expoId, ApplicationForTraineeRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
@@ -30,6 +33,8 @@ public class FieldApplicationForTraineeServiceImpl implements FieldApplicationFo
             throw new AlreadyApplicationUserException();
 
         saveTrainee(dto, expo);
+
+        applicationEventPublisher.publishEvent(new SendQrEvent(expoId, dto.getPhoneNumber(), Authority.ROLE_TRAINEE));
     }
 
     private void saveTrainee(ApplicationForTraineeRequestDto dto, Expo expo) {

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
@@ -1,6 +1,7 @@
 package team.startup.expo.domain.application.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import team.startup.expo.domain.admin.entity.Authority;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
@@ -10,6 +11,7 @@ import team.startup.expo.domain.application.presentation.dto.request.Application
 import team.startup.expo.domain.application.service.PreApplicationForParticipantService;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.sms.event.SendQrEvent;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
 import team.startup.expo.global.annotation.TransactionService;
@@ -21,6 +23,7 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
     private final ExpoRepository expoRepository;
     private final ParticipantRepository participantRepository;
     private final TraineeRepository traineeRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public void execute(String expoId, ApplicationForParticipantRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
@@ -30,6 +33,8 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
             throw new AlreadyApplicationUserException();
 
         saveParticipant(expo, dto);
+
+        applicationEventPublisher.publishEvent(new SendQrEvent(expoId, dto.getPhoneNumber(), Authority.ROLE_STANDARD));
     }
 
     private void saveParticipant(Expo expo, ApplicationForParticipantRequestDto dto) {

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
@@ -1,6 +1,7 @@
 package team.startup.expo.domain.application.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import team.startup.expo.domain.admin.entity.Authority;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
@@ -9,6 +10,7 @@ import team.startup.expo.domain.application.exception.AlreadyApplicationUserExce
 import team.startup.expo.domain.application.presentation.dto.request.ApplicationForTraineeRequestDto;
 import team.startup.expo.domain.application.service.PreApplicationForTraineeService;
 import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.sms.event.SendQrEvent;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.domain.trainee.entity.Trainee;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
@@ -21,7 +23,7 @@ public class PreApplicationForTraineeServiceImpl implements PreApplicationForTra
     private final TraineeRepository traineeRepository;
     private final ExpoRepository expoRepository;
     private final ParticipantRepository participantRepository;
-
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public void execute(String expoId, ApplicationForTraineeRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
@@ -31,6 +33,8 @@ public class PreApplicationForTraineeServiceImpl implements PreApplicationForTra
             throw new AlreadyApplicationUserException();
 
         saveTrainee(dto, expo);
+
+        applicationEventPublisher.publishEvent(new SendQrEvent(expoId, dto.getPhoneNumber(), Authority.ROLE_TRAINEE));
     }
 
     private void saveTrainee(ApplicationForTraineeRequestDto dto, Expo expo) {

--- a/src/main/java/team/startup/expo/domain/sms/event/SendQrEvent.java
+++ b/src/main/java/team/startup/expo/domain/sms/event/SendQrEvent.java
@@ -1,0 +1,13 @@
+package team.startup.expo.domain.sms.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import team.startup.expo.domain.admin.entity.Authority;
+
+@Getter
+@AllArgsConstructor
+public class SendQrEvent {
+    private String expoId;
+    private String phoneNumber;
+    private Authority authority;
+}

--- a/src/main/java/team/startup/expo/domain/sms/event/handler/SendQrEventHandler.java
+++ b/src/main/java/team/startup/expo/domain/sms/event/handler/SendQrEventHandler.java
@@ -1,0 +1,129 @@
+package team.startup.expo.domain.sms.event.handler;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.MultiFormatWriter;
+import com.google.zxing.WriterException;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.model.StorageType;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import team.startup.expo.domain.admin.entity.Authority;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.expo.exception.NotFoundExpoException;
+import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.participant.entity.StandardParticipant;
+import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.sms.event.SendQrEvent;
+import team.startup.expo.domain.sms.exception.NotFoundParticipantException;
+import team.startup.expo.domain.sms.exception.NotFoundTraineeException;
+import team.startup.expo.domain.trainee.entity.Trainee;
+import team.startup.expo.domain.trainee.repository.TraineeRepository;
+import team.startup.expo.global.sms.SmsProperties;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SendQrEventHandler {
+
+    private final static int WIDTH = 200;
+    private final static int HEIGHT = 200;
+
+    private final ParticipantRepository participantRepository;
+    private final ExpoRepository expoRepository;
+    private final DefaultMessageService messageService;
+    private final TraineeRepository traineeRepository;
+    private final SmsProperties smsProperties;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public SingleMessageSentResponse sendQrHandler(SendQrEvent sendQrEvent) {
+        SingleMessageSentResponse response = null;
+
+        Expo expo = expoRepository.findById(sendQrEvent.getExpoId())
+                .orElseThrow(NotFoundExpoException::new);
+
+        if (sendQrEvent.getAuthority() == Authority.ROLE_STANDARD) {
+            StandardParticipant participant = participantRepository.findByPhoneNumberAndExpo(sendQrEvent.getPhoneNumber(), expo)
+                    .orElseThrow(NotFoundParticipantException::new);
+
+            String information = "{\"participantId\": " + participant.getId() + ", \"phoneNumber\": \"" + participant.getPhoneNumber() + "\"}";
+            byte[] qrBytes = createQr(information);
+
+            participant.addQrCode(qrBytes);
+
+            Message message = createMessage(qrBytes, sendQrEvent);
+
+            response = messageService.sendOne(new SingleMessageSendingRequest(message));
+        } else if (sendQrEvent.getAuthority() == Authority.ROLE_TRAINEE) {
+            Trainee trainee = traineeRepository.findByPhoneNumberAndExpo(sendQrEvent.getPhoneNumber(), expo)
+                    .orElseThrow(NotFoundTraineeException::new);
+
+            String information = "{\"traineeId\": " + trainee.getId() + ", \"phoneNumber\": \"" + trainee.getPhoneNumber() + "\"}";
+
+            byte[] qrBytes = createQr(information);
+
+            trainee.addQrCode(qrBytes);
+
+            Message message = createMessage(qrBytes, sendQrEvent);
+
+            response = messageService.sendOne(new SingleMessageSendingRequest(message));
+        }
+
+        return response;
+    }
+
+    private byte[] createQr(String information) {
+        byte[] bytes = null;
+        try {
+            BitMatrix encode = new MultiFormatWriter().encode(information, BarcodeFormat.QR_CODE, WIDTH, HEIGHT);
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+            MatrixToImageWriter.writeToStream(encode, "JPG", out);
+
+            bytes = out.toByteArray();
+        } catch (IOException | WriterException e) {
+            log.error(e.getMessage(), e);
+        }
+
+        return bytes;
+    }
+
+    private Message createMessage(byte[] qrBytes, SendQrEvent sendQrEvent) {
+        try {
+            Path tempFilePath = Files.createTempFile("temp-qr", ".jpg");
+            Files.write(tempFilePath, qrBytes);
+            File tempFile = tempFilePath.toFile();
+
+            String imageId;
+            try {
+                imageId = messageService.uploadFile(tempFile, StorageType.MMS, null);
+            } finally {
+                tempFile.delete();
+            }
+
+            Message message = new Message();
+            message.setFrom(smsProperties.getFromNumber());
+            message.setTo(sendQrEvent.getPhoneNumber());
+            message.setText("QR 코드가 포함된 메시지입니다.");
+            message.setImageId(imageId);
+
+            return message;
+        } catch (IOException e) {}
+
+        return null;
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요

박람회 신청 후 Qr을 발송하는 과정에서 신청이 되지 않아도 QR이 발송되거나 다른 문제들이 발견되어 QR 전송을 이벤트로 만들어 신청이 정상적으로 되면 발송되게 처리하였습니다

Resolves: #166 

## 📃 작업내용

* SendQr을 ApplicationEvent로 만들어 비동기 처리
* application에 존재하는 모든 api에 동일하게 적용

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타