### PR TITLE
🔀 :: 박람회 연수자 / 참가자 문자 보내기 예외처리 문제

### DIFF
--- a/src/main/java/team/startup/expo/domain/sms/service/impl/SendMessageServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/sms/service/impl/SendMessageServiceImpl.java
@@ -50,7 +50,7 @@ public class SendMessageServiceImpl implements SendMessageService {
         List<Trainee> traineeList = traineeRepository.findByExpo(expo);
 
         if (traineeList.isEmpty())
-            throw new NotExistParticipantAtExpoException();
+            throw new NotExistTraineeAtExpoException();
 
         ArrayList<Message> messageList = new ArrayList<>();
 
@@ -70,7 +70,7 @@ public class SendMessageServiceImpl implements SendMessageService {
         List<StandardParticipant> participantList = participantRepository.findByExpo(expo);
 
         if (participantList.isEmpty())
-            throw new NotExistTraineeAtExpoException();
+            throw new NotExistParticipantAtExpoException();
 
         ArrayList<Message> messageList = new ArrayList<>();
 


### PR DESCRIPTION
## 💡 배경 및 개요

박람회 내에서 연수자와 참가자 문자 보내기 로직 중 박람회 내에 조회 했을 경우 존재하는지 검증하는 조건문에서 예외처리가 서로 바껴 잘못되어 있던 문제를 수정하였습니다

Resolves: #172 

## 📃 작업내용

* sendMessageForTrainee(Participant) if문 수정

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타