### PR TITLE
🔀 :: 박람회 출석 관련 테이블 분리 및 출석 로직 수정

### DIFF
--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import team.startup.expo.domain.admin.entity.Authority;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
+import team.startup.expo.domain.expo.exception.NotInProgressExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.application.exception.AlreadyApplicationUserException;
 import team.startup.expo.domain.application.presentation.dto.request.ApplicationForParticipantRequestDto;
@@ -15,6 +16,7 @@ import team.startup.expo.domain.sms.event.SendQrEvent;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
 import team.startup.expo.global.annotation.TransactionService;
+import team.startup.expo.global.date.DateUtil;
 
 @TransactionService
 @RequiredArgsConstructor
@@ -24,10 +26,14 @@ public class FieldApplicationForParticipantServiceImpl implements FieldApplicati
     private final StandardParticipantRepository standardParticipantRepository;
     private final TraineeRepository traineeRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final DateUtil dateUtil;
 
     public void execute(String expoId, ApplicationForParticipantRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
+
+        if (!dateUtil.dateComparison(expo.getStartedDay(), expo.getFinishedDay()))
+            throw new NotInProgressExpoException();
 
         if (standardParticipantRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo) || traineeRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo))
             throw new AlreadyApplicationUserException();

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
@@ -10,9 +10,8 @@ import team.startup.expo.domain.application.exception.AlreadyApplicationUserExce
 import team.startup.expo.domain.application.presentation.dto.request.ApplicationForParticipantRequestDto;
 import team.startup.expo.domain.application.service.FieldApplicationForParticipantService;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
-import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.sms.event.SendQrEvent;
-import team.startup.expo.domain.sms.event.handler.SendQrEventHandler;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
 import team.startup.expo.global.annotation.TransactionService;
@@ -22,7 +21,7 @@ import team.startup.expo.global.annotation.TransactionService;
 public class FieldApplicationForParticipantServiceImpl implements FieldApplicationForParticipantService {
 
     private final ExpoRepository expoRepository;
-    private final ParticipantRepository participantRepository;
+    private final StandardParticipantRepository standardParticipantRepository;
     private final TraineeRepository traineeRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
@@ -30,7 +29,7 @@ public class FieldApplicationForParticipantServiceImpl implements FieldApplicati
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
-        if (participantRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo) || traineeRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo))
+        if (standardParticipantRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo) || traineeRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo))
             throw new AlreadyApplicationUserException();
 
         saveParticipant(expo, dto);
@@ -50,6 +49,6 @@ public class FieldApplicationForParticipantServiceImpl implements FieldApplicati
                 .expo(expo)
                 .build();
 
-        participantRepository.save(standardParticipant);
+        standardParticipantRepository.save(standardParticipant);
     }
 }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
@@ -42,7 +42,6 @@ public class FieldApplicationForParticipantServiceImpl implements FieldApplicati
                 .name(dto.getName())
                 .phoneNumber(dto.getPhoneNumber())
                 .authority(Authority.ROLE_STANDARD)
-                .attendanceStatus(false)
                 .informationJson(dto.getInformationJson())
                 .applicationType(ApplicationType.FIELD)
                 .personalInformationStatus(dto.getPersonalInformationStatus())

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForTraineeServiceImpl.java
@@ -9,7 +9,7 @@ import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.application.exception.AlreadyApplicationUserException;
 import team.startup.expo.domain.application.presentation.dto.request.ApplicationForTraineeRequestDto;
 import team.startup.expo.domain.application.service.FieldApplicationForTraineeService;
-import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.sms.event.SendQrEvent;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.domain.trainee.entity.Trainee;
@@ -22,14 +22,14 @@ public class FieldApplicationForTraineeServiceImpl implements FieldApplicationFo
 
     private final TraineeRepository traineeRepository;
     private final ExpoRepository expoRepository;
-    private final ParticipantRepository participantRepository;
+    private final StandardParticipantRepository standardParticipantRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     public void execute(String expoId, ApplicationForTraineeRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
-        if (participantRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo) || traineeRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo))
+        if (standardParticipantRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo) || traineeRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo))
             throw new AlreadyApplicationUserException();
 
         saveTrainee(dto, expo);

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForTraineeServiceImpl.java
@@ -46,7 +46,6 @@ public class FieldApplicationForTraineeServiceImpl implements FieldApplicationFo
                 .applicationType(ApplicationType.FIELD)
                 .informationJson(dto.getInformationJson())
                 .personalInformationStatus(dto.getPersonalInformationStatus())
-                .attendanceStatus(false)
                 .expo(expo)
                 .build();
 

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
@@ -10,7 +10,7 @@ import team.startup.expo.domain.application.exception.AlreadyApplicationUserExce
 import team.startup.expo.domain.application.presentation.dto.request.ApplicationForParticipantRequestDto;
 import team.startup.expo.domain.application.service.PreApplicationForParticipantService;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
-import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.sms.event.SendQrEvent;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
@@ -21,7 +21,7 @@ import team.startup.expo.global.annotation.TransactionService;
 public class PreApplicationForParticipantServiceImpl implements PreApplicationForParticipantService {
 
     private final ExpoRepository expoRepository;
-    private final ParticipantRepository participantRepository;
+    private final StandardParticipantRepository standardParticipantRepository;
     private final TraineeRepository traineeRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
@@ -29,7 +29,7 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
-        if (participantRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo) || traineeRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo))
+        if (standardParticipantRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo) || traineeRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo))
             throw new AlreadyApplicationUserException();
 
         saveParticipant(expo, dto);
@@ -49,6 +49,6 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
                 .expo(expo)
                 .build();
 
-        participantRepository.save(standardParticipant);
+        standardParticipantRepository.save(standardParticipant);
     }
 }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
@@ -42,7 +42,6 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
                 .name(dto.getName())
                 .phoneNumber(dto.getPhoneNumber())
                 .authority(Authority.ROLE_STANDARD)
-                .attendanceStatus(false)
                 .informationJson(dto.getInformationJson())
                 .applicationType(ApplicationType.PRE)
                 .personalInformationStatus(dto.getPersonalInformationStatus())

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import team.startup.expo.domain.admin.entity.Authority;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
+import team.startup.expo.domain.expo.exception.NotInProgressExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.application.exception.AlreadyApplicationUserException;
 import team.startup.expo.domain.application.presentation.dto.request.ApplicationForParticipantRequestDto;
@@ -15,6 +16,7 @@ import team.startup.expo.domain.sms.event.SendQrEvent;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
 import team.startup.expo.global.annotation.TransactionService;
+import team.startup.expo.global.date.DateUtil;
 
 @TransactionService
 @RequiredArgsConstructor
@@ -24,10 +26,14 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
     private final StandardParticipantRepository standardParticipantRepository;
     private final TraineeRepository traineeRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final DateUtil dateUtil;
 
     public void execute(String expoId, ApplicationForParticipantRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
+
+        if (!dateUtil.dateComparison(expo.getStartedDay(), expo.getFinishedDay()))
+            throw new NotInProgressExpoException();
 
         if (standardParticipantRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo) || traineeRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo))
             throw new AlreadyApplicationUserException();

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
@@ -9,7 +9,7 @@ import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.application.exception.AlreadyApplicationUserException;
 import team.startup.expo.domain.application.presentation.dto.request.ApplicationForTraineeRequestDto;
 import team.startup.expo.domain.application.service.PreApplicationForTraineeService;
-import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.sms.event.SendQrEvent;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.domain.trainee.entity.Trainee;
@@ -22,14 +22,14 @@ public class PreApplicationForTraineeServiceImpl implements PreApplicationForTra
 
     private final TraineeRepository traineeRepository;
     private final ExpoRepository expoRepository;
-    private final ParticipantRepository participantRepository;
+    private final StandardParticipantRepository standardParticipantRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     public void execute(String expoId, ApplicationForTraineeRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
-        if (participantRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo) || traineeRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo))
+        if (standardParticipantRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo) || traineeRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo))
             throw new AlreadyApplicationUserException();
 
         saveTrainee(dto, expo);

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import team.startup.expo.domain.admin.entity.Authority;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
+import team.startup.expo.domain.expo.exception.NotInProgressExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.application.exception.AlreadyApplicationUserException;
 import team.startup.expo.domain.application.presentation.dto.request.ApplicationForTraineeRequestDto;
@@ -15,6 +16,7 @@ import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.domain.trainee.entity.Trainee;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
 import team.startup.expo.global.annotation.TransactionService;
+import team.startup.expo.global.date.DateUtil;
 
 @TransactionService
 @RequiredArgsConstructor
@@ -24,10 +26,14 @@ public class PreApplicationForTraineeServiceImpl implements PreApplicationForTra
     private final ExpoRepository expoRepository;
     private final StandardParticipantRepository standardParticipantRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final DateUtil dateUtil;
 
     public void execute(String expoId, ApplicationForTraineeRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
+
+        if (!dateUtil.dateComparison(expo.getStartedDay(), expo.getFinishedDay()))
+            throw new NotInProgressExpoException();
 
         if (standardParticipantRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo) || traineeRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo))
             throw new AlreadyApplicationUserException();

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
@@ -46,7 +46,6 @@ public class PreApplicationForTraineeServiceImpl implements PreApplicationForTra
                 .applicationType(ApplicationType.PRE)
                 .informationJson(dto.getInformationJson())
                 .personalInformationStatus(dto.getPersonalInformationStatus())
-                .attendanceStatus(false)
                 .expo(expo)
                 .build();
 

--- a/src/main/java/team/startup/expo/domain/attendance/presentation/dto/response/PreEnterScanQrCodeResponseDto.java
+++ b/src/main/java/team/startup/expo/domain/attendance/presentation/dto/response/PreEnterScanQrCodeResponseDto.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @Builder
 public class PreEnterScanQrCodeResponseDto {
     private String name;
-    private String affiliation;
-    private byte[] qrCode;
+    private String phoneNumber;
+    private Boolean personalInformationStatus;
 }

--- a/src/main/java/team/startup/expo/domain/attendance/service/impl/PreEnterScanQrCodeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/attendance/service/impl/PreEnterScanQrCodeServiceImpl.java
@@ -10,20 +10,30 @@ import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
+import team.startup.expo.domain.participant.entity.StandardParticipantParticipation;
+import team.startup.expo.domain.participant.repository.StandardParticipantParticipationRepository;
 import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.sms.exception.NotFoundParticipantException;
 import team.startup.expo.domain.sms.exception.NotFoundTraineeException;
 import team.startup.expo.domain.trainee.entity.Trainee;
+import team.startup.expo.domain.trainee.entity.TraineeParticipation;
+import team.startup.expo.domain.trainee.repository.TraineeParticipationRepository;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
 import team.startup.expo.global.annotation.TransactionService;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @TransactionService
 @RequiredArgsConstructor
 public class PreEnterScanQrCodeServiceImpl implements PreEnterScanQrCodeService {
 
+    private final ExpoRepository expoRepository;
     private final TraineeRepository traineeRepository;
     private final StandardParticipantRepository standardParticipantRepository;
-    private final ExpoRepository expoRepository;
+    private final TraineeParticipationRepository traineeParticipationRepository;
+    private final StandardParticipantParticipationRepository standardParticipantParticipationRepository;
 
     public PreEnterScanQrCodeResponseDto execute(String expoId, PreEnterScanQrCodeRequestDto dto) {
         PreEnterScanQrCodeResponseDto responseDto = null;
@@ -31,34 +41,67 @@ public class PreEnterScanQrCodeServiceImpl implements PreEnterScanQrCodeService 
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
-        if (dto.getAuthority() == Authority.ROLE_STANDARD) {
-            StandardParticipant participant = standardParticipantRepository.findByPhoneNumberAndExpo(dto.getPhoneNumber(), expo)
-                    .orElseThrow(NotFoundParticipantException::new);
-
-            if (participant.getAttendanceStatus())
-                throw new AlreadyEnterExpoUserException();
-
-            participant.changeAttendanceStatus();
-
-            responseDto = PreEnterScanQrCodeResponseDto.builder()
-                    .name(participant.getName())
-                    .qrCode(participant.getQrCode())
-                    .build();
-        } else if (dto.getAuthority() == Authority.ROLE_TRAINEE) {
-            Trainee trainee = traineeRepository.findByPhoneNumberAndExpo(dto.getPhoneNumber(), expo)
-                    .orElseThrow(NotFoundTraineeException::new);
-
-            if (trainee.getAttendanceStatus())
-                throw new AlreadyEnterExpoUserException();
-
-            trainee.changeAttendanceStatus();
-
-            responseDto = PreEnterScanQrCodeResponseDto.builder()
-                    .name(trainee.getName())
-                    .qrCode(trainee.getQrCode())
-                    .build();
+        switch (dto.getAuthority()){
+            case ROLE_STANDARD -> responseDto = standardParticipantEnterProcess(expo, dto);
+            case ROLE_TRAINEE -> responseDto = traineeEnterProcess(expo, dto);
         }
 
         return responseDto;
+    }
+
+    private PreEnterScanQrCodeResponseDto standardParticipantEnterProcess(Expo expo, PreEnterScanQrCodeRequestDto dto) {
+        StandardParticipant standardParticipant = standardParticipantRepository.findByPhoneNumberAndExpo(dto.getPhoneNumber(), expo)
+                .orElseThrow(NotFoundParticipantException::new);
+
+        Optional<StandardParticipantParticipation> standardParticipantParticipation =
+                standardParticipantParticipationRepository.findByExpoAndStandardParticipantAndAttendanceDate(expo, standardParticipant, LocalDate.now());
+
+        if (standardParticipantParticipation.isPresent()) {
+            StandardParticipantParticipation getStandardParticipantParticipation = standardParticipantParticipation.get();
+            getStandardParticipantParticipation.addLeaveTime();
+        } else {
+            StandardParticipantParticipation newStandardParticipantParticipation = StandardParticipantParticipation.builder()
+                    .entryTime(LocalDateTime.now())
+                    .attendanceDate(LocalDate.now())
+                    .standardParticipant(standardParticipant)
+                    .expo(expo)
+                    .build();
+
+            standardParticipantParticipationRepository.save(newStandardParticipantParticipation);
+        }
+
+        return PreEnterScanQrCodeResponseDto.builder()
+                .name(standardParticipant.getName())
+                .phoneNumber(standardParticipant.getPhoneNumber())
+                .personalInformationStatus(standardParticipant.getPersonalInformationStatus())
+                .build();
+    }
+
+    private PreEnterScanQrCodeResponseDto traineeEnterProcess(Expo expo, PreEnterScanQrCodeRequestDto dto) {
+        Trainee trainee = traineeRepository.findByPhoneNumberAndExpo(dto.getPhoneNumber(), expo)
+                .orElseThrow(NotFoundTraineeException::new);
+
+        Optional<TraineeParticipation> traineeParticipation =
+                traineeParticipationRepository.findByExpoAndTraineeAndAttendanceDate(expo, trainee, LocalDate.now());
+
+        if (traineeParticipation.isPresent()) {
+            TraineeParticipation getTraineeParticipation = traineeParticipation.get();
+            getTraineeParticipation.addLeaveTime();
+        } else {
+            TraineeParticipation newTraineeParticipation = TraineeParticipation.builder()
+                    .entryTime(LocalDateTime.now())
+                    .attendanceDate(LocalDate.now())
+                    .trainee(trainee)
+                    .expo(expo)
+                    .build();
+
+            traineeParticipationRepository.save(newTraineeParticipation);
+        }
+
+        return PreEnterScanQrCodeResponseDto.builder()
+                .name(trainee.getName())
+                .phoneNumber(trainee.getPhoneNumber())
+                .personalInformationStatus(trainee.getPersonalInformationStatus())
+                .build();
     }
 }

--- a/src/main/java/team/startup/expo/domain/attendance/service/impl/PreEnterScanQrCodeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/attendance/service/impl/PreEnterScanQrCodeServiceImpl.java
@@ -10,7 +10,7 @@ import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
-import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.sms.exception.NotFoundParticipantException;
 import team.startup.expo.domain.sms.exception.NotFoundTraineeException;
 import team.startup.expo.domain.trainee.entity.Trainee;
@@ -22,7 +22,7 @@ import team.startup.expo.global.annotation.TransactionService;
 public class PreEnterScanQrCodeServiceImpl implements PreEnterScanQrCodeService {
 
     private final TraineeRepository traineeRepository;
-    private final ParticipantRepository participantRepository;
+    private final StandardParticipantRepository standardParticipantRepository;
     private final ExpoRepository expoRepository;
 
     public PreEnterScanQrCodeResponseDto execute(String expoId, PreEnterScanQrCodeRequestDto dto) {
@@ -32,7 +32,7 @@ public class PreEnterScanQrCodeServiceImpl implements PreEnterScanQrCodeService 
                 .orElseThrow(NotFoundExpoException::new);
 
         if (dto.getAuthority() == Authority.ROLE_STANDARD) {
-            StandardParticipant participant = participantRepository.findByPhoneNumberAndExpo(dto.getPhoneNumber(), expo)
+            StandardParticipant participant = standardParticipantRepository.findByPhoneNumberAndExpo(dto.getPhoneNumber(), expo)
                     .orElseThrow(NotFoundParticipantException::new);
 
             if (participant.getAttendanceStatus())

--- a/src/main/java/team/startup/expo/domain/attendance/service/impl/ScanStandardProByQrCodeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/attendance/service/impl/ScanStandardProByQrCodeServiceImpl.java
@@ -5,6 +5,7 @@ import team.startup.expo.domain.attendance.exception.NotFoundStandardProgramExce
 import team.startup.expo.domain.attendance.exception.NotFoundStandardProgramUserException;
 import team.startup.expo.domain.attendance.presentation.dto.request.ScanStandardProRequestDto;
 import team.startup.expo.domain.attendance.service.ScanStandardProByQrCodeService;
+import team.startup.expo.domain.expo.exception.NotInProgressExpoException;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.sms.exception.NotFoundParticipantException;
@@ -13,6 +14,7 @@ import team.startup.expo.domain.standard.entity.StandardProgramUser;
 import team.startup.expo.domain.standard.repository.StandardProgramRepository;
 import team.startup.expo.domain.standard.repository.StandardProgramUserRepository;
 import team.startup.expo.global.annotation.TransactionService;
+import team.startup.expo.global.date.DateUtil;
 
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
@@ -24,6 +26,7 @@ public class ScanStandardProByQrCodeServiceImpl implements ScanStandardProByQrCo
     private final StandardParticipantRepository standardParticipantRepository;
     private final StandardProgramRepository standardProgramRepository;
     private final StandardProgramUserRepository standardProgramUserRepository;
+    private final DateUtil dateUtil;
 
     public void execute(Long standardProId, ScanStandardProRequestDto dto) {
         StandardParticipant standardParticipant = standardParticipantRepository.findById(dto.getParticipantId())
@@ -31,6 +34,9 @@ public class ScanStandardProByQrCodeServiceImpl implements ScanStandardProByQrCo
 
         StandardProgram standardProgram = standardProgramRepository.findById(standardProId)
                 .orElseThrow(NotFoundStandardProgramException::new);
+
+        if (!dateUtil.dateComparison(standardProgram.getExpo().getStartedDay(), standardProgram.getExpo().getFinishedDay()))
+            throw new NotInProgressExpoException();
 
         StandardProgramUser standardProgramUser = standardProgramUserRepository.findByStandardProgramAndStandardParticipant(standardProgram, standardParticipant)
                 .orElseThrow(NotFoundStandardProgramUserException::new);

--- a/src/main/java/team/startup/expo/domain/attendance/service/impl/ScanStandardProByQrCodeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/attendance/service/impl/ScanStandardProByQrCodeServiceImpl.java
@@ -6,7 +6,7 @@ import team.startup.expo.domain.attendance.exception.NotFoundStandardProgramUser
 import team.startup.expo.domain.attendance.presentation.dto.request.ScanStandardProRequestDto;
 import team.startup.expo.domain.attendance.service.ScanStandardProByQrCodeService;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
-import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.sms.exception.NotFoundParticipantException;
 import team.startup.expo.domain.standard.entity.StandardProgram;
 import team.startup.expo.domain.standard.entity.StandardProgramUser;
@@ -21,12 +21,12 @@ import java.time.temporal.ChronoUnit;
 @RequiredArgsConstructor
 public class ScanStandardProByQrCodeServiceImpl implements ScanStandardProByQrCodeService {
 
-    private final ParticipantRepository participantRepository;
+    private final StandardParticipantRepository standardParticipantRepository;
     private final StandardProgramRepository standardProgramRepository;
     private final StandardProgramUserRepository standardProgramUserRepository;
 
     public void execute(Long standardProId, ScanStandardProRequestDto dto) {
-        StandardParticipant standardParticipant = participantRepository.findById(dto.getParticipantId())
+        StandardParticipant standardParticipant = standardParticipantRepository.findById(dto.getParticipantId())
                 .orElseThrow(NotFoundParticipantException::new);
 
         StandardProgram standardProgram = standardProgramRepository.findById(standardProId)

--- a/src/main/java/team/startup/expo/domain/attendance/service/impl/ScanTrainingProByQrCodeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/attendance/service/impl/ScanTrainingProByQrCodeServiceImpl.java
@@ -5,6 +5,8 @@ import team.startup.expo.domain.attendance.exception.NotFoundTrainingProgramUser
 import team.startup.expo.domain.attendance.presentation.dto.request.ScanTrainingProRequestDto;
 import team.startup.expo.domain.attendance.service.ScanTrainingProByQrCodeService;
 import java.time.LocalTime;
+
+import team.startup.expo.domain.expo.exception.NotInProgressExpoException;
 import team.startup.expo.domain.sms.exception.NotFoundTraineeException;
 import team.startup.expo.domain.trainee.entity.Trainee;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
@@ -14,6 +16,7 @@ import team.startup.expo.domain.training.exception.NotFoundTrainingProgramExcept
 import team.startup.expo.domain.training.repository.TrainingProgramRepository;
 import team.startup.expo.domain.training.repository.TrainingProgramUserRepository;
 import team.startup.expo.global.annotation.TransactionService;
+import team.startup.expo.global.date.DateUtil;
 
 import java.time.temporal.ChronoUnit;
 
@@ -24,6 +27,7 @@ public class ScanTrainingProByQrCodeServiceImpl implements ScanTrainingProByQrCo
     private final TrainingProgramRepository trainingProgramRepository;
     private final TrainingProgramUserRepository trainingProgramUserRepository;
     private final TraineeRepository traineeRepository;
+    private final DateUtil dateUtil;
 
     public void execute(Long trainingProId, ScanTrainingProRequestDto dto) {
         Trainee trainee = traineeRepository.findById(dto.getTraineeId())
@@ -31,6 +35,9 @@ public class ScanTrainingProByQrCodeServiceImpl implements ScanTrainingProByQrCo
 
         TrainingProgram trainingProgram = trainingProgramRepository.findById(trainingProId)
                 .orElseThrow(NotFoundTrainingProgramException::new);
+
+        if (!dateUtil.dateComparison(trainingProgram.getExpo().getStartedDay(), trainingProgram.getExpo().getFinishedDay()))
+            throw new NotInProgressExpoException();
 
         TrainingProgramUser trainingProgramUser = trainingProgramUserRepository.findByTraineeAndTrainingProgram(trainee, trainingProgram)
                 .orElseThrow(NotFoundTrainingProgramUserException::new);

--- a/src/main/java/team/startup/expo/domain/expo/exception/NotInProgressExpoException.java
+++ b/src/main/java/team/startup/expo/domain/expo/exception/NotInProgressExpoException.java
@@ -1,0 +1,10 @@
+package team.startup.expo.domain.expo.exception;
+
+import team.startup.expo.global.exception.ErrorCode;
+import team.startup.expo.global.exception.GlobalException;
+
+public class NotInProgressExpoException extends GlobalException {
+    public NotInProgressExpoException() {
+        super(ErrorCode.NOT_IN_PROGRESS_EXPO);
+    }
+}

--- a/src/main/java/team/startup/expo/domain/expo/service/impl/DeleteExpoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/impl/DeleteExpoServiceImpl.java
@@ -8,7 +8,7 @@ import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.exception.NotMatchAdminException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.expo.service.DeleteExpoService;
-import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.standard.entity.StandardProgram;
 import team.startup.expo.domain.standard.repository.StandardProgramRepository;
 import team.startup.expo.domain.standard.repository.StandardProgramUserRepository;
@@ -28,7 +28,7 @@ public class DeleteExpoServiceImpl implements DeleteExpoService {
     private final StandardProgramRepository standardProgramRepository;
     private final StandardProgramUserRepository standardProgramUserRepository;
     private final TrainingProgramUserRepository trainingProgramUserRepository;
-    private final ParticipantRepository participantRepository;
+    private final StandardParticipantRepository standardParticipantRepository;
     private final TraineeRepository traineeRepository;
     private final TrainingProgramRepository trainingProgramRepository;
     private final UserUtil userUtil;
@@ -53,7 +53,7 @@ public class DeleteExpoServiceImpl implements DeleteExpoService {
 
         standardProgramRepository.deleteByExpo(expo);
         trainingProgramRepository.deleteByExpo(expo);
-        participantRepository.deleteByExpo(expo);
+        standardParticipantRepository.deleteByExpo(expo);
         traineeRepository.deleteByExpo(expo);
         expoRepository.delete(expo);
     }

--- a/src/main/java/team/startup/expo/domain/participant/entity/StandardParticipant.java
+++ b/src/main/java/team/startup/expo/domain/participant/entity/StandardParticipant.java
@@ -37,9 +37,6 @@ public class StandardParticipant {
     @Column(nullable = false, columnDefinition = "TINYINT(1)")
     private Boolean personalInformationStatus;
 
-    @Column(nullable = false, columnDefinition = "TINYINT(1)")
-    private Boolean attendanceStatus = false;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ApplicationType applicationType;
@@ -51,10 +48,6 @@ public class StandardParticipant {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "expo_id")
     private Expo expo;
-
-    public void changeAttendanceStatus() {
-        this.attendanceStatus = true;
-    }
 
     public void addQrCode(byte[] qrCode) {
         this.qrCode = qrCode;

--- a/src/main/java/team/startup/expo/domain/participant/entity/StandardParticipantParticipation.java
+++ b/src/main/java/team/startup/expo/domain/participant/entity/StandardParticipantParticipation.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team.startup.expo.domain.expo.entity.Expo;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -33,4 +34,12 @@ public class StandardParticipantParticipation {
     @JoinColumn(name = "standard_participant_id")
     @ManyToOne
     private StandardParticipant standardParticipant;
+
+    @JoinColumn(name = "expo_id")
+    @ManyToOne
+    private Expo expo;
+
+    public void addLeaveTime() {
+        this.leaveTime = LocalDateTime.now();
+    }
 }

--- a/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantParticipationRepository.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantParticipationRepository.java
@@ -1,0 +1,7 @@
+package team.startup.expo.domain.participant.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.startup.expo.domain.participant.entity.StandardParticipantParticipation;
+
+public interface StandardParticipantParticipationRepository extends JpaRepository<StandardParticipantParticipation, Long> {
+}

--- a/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantParticipationRepository.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantParticipationRepository.java
@@ -1,7 +1,13 @@
 package team.startup.expo.domain.participant.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.participant.entity.StandardParticipantParticipation;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 public interface StandardParticipantParticipationRepository extends JpaRepository<StandardParticipantParticipation, Long> {
+    Optional<StandardParticipantParticipation> findByExpoAndStandardParticipantAndAttendanceDate(Expo expo, StandardParticipant standardParticipant, LocalDate attendanceDate);
 }

--- a/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantRepository.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantRepository.java
@@ -8,7 +8,7 @@ import team.startup.expo.domain.trainee.entity.ApplicationType;
 import java.util.List;
 import java.util.Optional;
 
-public interface ParticipantRepository extends JpaRepository<StandardParticipant, Long> {
+public interface StandardParticipantRepository extends JpaRepository<StandardParticipant, Long> {
     Optional<StandardParticipant> findByPhoneNumberAndExpo(String phoneNumber, Expo expo);
     void deleteByExpo(Expo expo);
     List<StandardParticipant> findByExpoAndApplicationTypeAndName(Expo expo, ApplicationType applicationType, String name);

--- a/src/main/java/team/startup/expo/domain/participant/service/impl/GetParticipantInfoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/participant/service/impl/GetParticipantInfoServiceImpl.java
@@ -6,7 +6,7 @@ import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.participant.presentation.dto.response.GetParticipantInfoResponseDto;
-import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.participant.service.GetParticipantInfoService;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.global.annotation.ReadOnlyTransactionService;
@@ -17,7 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class GetParticipantInfoServiceImpl implements GetParticipantInfoService {
 
-    private final ParticipantRepository participantRepository;
+    private final StandardParticipantRepository standardParticipantRepository;
     private final ExpoRepository expoRepository;
 
     public List<GetParticipantInfoResponseDto> execute(String expoId, ApplicationType type, String name) {
@@ -27,9 +27,9 @@ public class GetParticipantInfoServiceImpl implements GetParticipantInfoService 
         List<StandardParticipant> participantList;
 
         if (name == null) {
-            participantList = participantRepository.findByExpoAndApplicationType(expo, type);
+            participantList = standardParticipantRepository.findByExpoAndApplicationType(expo, type);
         } else {
-            participantList = participantRepository.findByExpoAndApplicationTypeAndName(expo, type, name);
+            participantList = standardParticipantRepository.findByExpoAndApplicationTypeAndName(expo, type, name);
         }
 
         return participantList.stream()

--- a/src/main/java/team/startup/expo/domain/sms/event/handler/SendQrEventHandler.java
+++ b/src/main/java/team/startup/expo/domain/sms/event/handler/SendQrEventHandler.java
@@ -20,7 +20,7 @@ import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
-import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.sms.event.SendQrEvent;
 import team.startup.expo.domain.sms.exception.NotFoundParticipantException;
 import team.startup.expo.domain.sms.exception.NotFoundTraineeException;
@@ -42,7 +42,7 @@ public class SendQrEventHandler {
     private final static int WIDTH = 200;
     private final static int HEIGHT = 200;
 
-    private final ParticipantRepository participantRepository;
+    private final StandardParticipantRepository standardParticipantRepository;
     private final ExpoRepository expoRepository;
     private final DefaultMessageService messageService;
     private final TraineeRepository traineeRepository;
@@ -56,7 +56,7 @@ public class SendQrEventHandler {
                 .orElseThrow(NotFoundExpoException::new);
 
         if (sendQrEvent.getAuthority() == Authority.ROLE_STANDARD) {
-            StandardParticipant participant = participantRepository.findByPhoneNumberAndExpo(sendQrEvent.getPhoneNumber(), expo)
+            StandardParticipant participant = standardParticipantRepository.findByPhoneNumberAndExpo(sendQrEvent.getPhoneNumber(), expo)
                     .orElseThrow(NotFoundParticipantException::new);
 
             String information = "{\"participantId\": " + participant.getId() + ", \"phoneNumber\": \"" + participant.getPhoneNumber() + "\"}";

--- a/src/main/java/team/startup/expo/domain/sms/service/impl/SendMessageServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/sms/service/impl/SendMessageServiceImpl.java
@@ -11,7 +11,7 @@ import team.startup.expo.domain.expo.exception.NotExistTraineeAtExpoException;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
-import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.sms.presentation.dto.request.SendMessageRequestDto;
 import team.startup.expo.domain.sms.service.SendMessageService;
 import team.startup.expo.domain.trainee.entity.Trainee;
@@ -29,7 +29,7 @@ public class SendMessageServiceImpl implements SendMessageService {
     private final DefaultMessageService messageService;
     private final SmsProperties smsProperties;
     private final TraineeRepository traineeRepository;
-    private final ParticipantRepository participantRepository;
+    private final StandardParticipantRepository standardParticipantRepository;
     private final ExpoRepository expoRepository;
 
     public MultipleDetailMessageSentResponse execute(String expoId, SendMessageRequestDto dto) {
@@ -67,7 +67,7 @@ public class SendMessageServiceImpl implements SendMessageService {
     }
 
     private MultipleDetailMessageSentResponse sendMessageForParticipant(Expo expo, SendMessageRequestDto dto) {
-        List<StandardParticipant> participantList = participantRepository.findByExpo(expo);
+        List<StandardParticipant> participantList = standardParticipantRepository.findByExpo(expo);
 
         if (participantList.isEmpty())
             throw new NotExistParticipantAtExpoException();

--- a/src/main/java/team/startup/expo/domain/sms/service/impl/SendQrServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/sms/service/impl/SendQrServiceImpl.java
@@ -17,7 +17,7 @@ import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
-import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.sms.exception.NotFoundParticipantException;
 import team.startup.expo.domain.sms.exception.NotFoundTraineeException;
 import team.startup.expo.domain.sms.presentation.dto.request.SendQrRequestDto;
@@ -41,7 +41,7 @@ public class SendQrServiceImpl implements SendQrService {
     private final static int WIDTH = 200;
     private final static int HEIGHT = 200;
 
-    private final ParticipantRepository participantRepository;
+    private final StandardParticipantRepository standardParticipantRepository;
     private final ExpoRepository expoRepository;
     private final DefaultMessageService messageService;
     private final TraineeRepository traineeRepository;
@@ -54,7 +54,7 @@ public class SendQrServiceImpl implements SendQrService {
                 .orElseThrow(NotFoundExpoException::new);
 
         if (dto.getAuthority() == Authority.ROLE_STANDARD) {
-            StandardParticipant participant = participantRepository.findByPhoneNumberAndExpo(dto.getPhoneNumber(), expo)
+            StandardParticipant participant = standardParticipantRepository.findByPhoneNumberAndExpo(dto.getPhoneNumber(), expo)
                     .orElseThrow(NotFoundParticipantException::new);
 
             String information = "{\"participantId\": " + participant.getId() + ", \"phoneNumber\": \"" + participant.getPhoneNumber() + "\"}";

--- a/src/main/java/team/startup/expo/domain/standard/service/impl/ApplicationStandardProListServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/standard/service/impl/ApplicationStandardProListServiceImpl.java
@@ -7,7 +7,7 @@ import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
-import team.startup.expo.domain.participant.repository.ParticipantRepository;
+import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.sms.exception.NotFoundParticipantException;
 import team.startup.expo.domain.standard.entity.StandardProgram;
 import team.startup.expo.domain.standard.entity.StandardProgramUser;
@@ -24,7 +24,7 @@ public class ApplicationStandardProListServiceImpl implements ApplicationStandar
 
     private final StandardProgramRepository standardProgramRepository;
     private final StandardProgramUserRepository standardProgramUserRepository;
-    private final ParticipantRepository participantRepository;
+    private final StandardParticipantRepository standardParticipantRepository;
     private final ExpoRepository expoRepository;
     private final TrainingProgramUserRepository trainingProgramUserRepository;
 
@@ -32,7 +32,7 @@ public class ApplicationStandardProListServiceImpl implements ApplicationStandar
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
-        StandardParticipant standardParticipant = participantRepository.findByPhoneNumberAndExpo(dto.getPhoneNumber(), expo)
+        StandardParticipant standardParticipant = standardParticipantRepository.findByPhoneNumberAndExpo(dto.getPhoneNumber(), expo)
                 .orElseThrow(NotFoundParticipantException::new);
 
         dto.getStandardProIds().forEach(standardProId -> {saveStandardProUser(standardParticipant, standardProId);});

--- a/src/main/java/team/startup/expo/domain/trainee/entity/Trainee.java
+++ b/src/main/java/team/startup/expo/domain/trainee/entity/Trainee.java
@@ -39,9 +39,6 @@ public class Trainee {
     @Column(nullable = false, columnDefinition = "TINYINT(1)")
     private Boolean personalInformationStatus;
 
-    @Column(nullable = false, columnDefinition = "TINYINT(1)")
-    private Boolean attendanceStatus = false;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ApplicationType applicationType;
@@ -53,10 +50,6 @@ public class Trainee {
     @ManyToOne
     @JoinColumn(name = "expo_id")
     private Expo expo;
-
-    public void changeAttendanceStatus() {
-        this.attendanceStatus = true;
-    }
 
     public void addQrCode(byte[] qrCode) {
         this.qrCode = qrCode;

--- a/src/main/java/team/startup/expo/domain/trainee/entity/TraineeParticipation.java
+++ b/src/main/java/team/startup/expo/domain/trainee/entity/TraineeParticipation.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team.startup.expo.domain.expo.entity.Expo;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -33,4 +34,12 @@ public class TraineeParticipation {
     @JoinColumn(name = "trainee_id")
     @ManyToOne
     private Trainee trainee;
+
+    @JoinColumn(name = "expo_id")
+    @ManyToOne
+    private Expo expo;
+
+    public void addLeaveTime() {
+        this.leaveTime = LocalDateTime.now();
+    }
 }

--- a/src/main/java/team/startup/expo/domain/trainee/repository/TraineeParticipationRepository.java
+++ b/src/main/java/team/startup/expo/domain/trainee/repository/TraineeParticipationRepository.java
@@ -1,0 +1,14 @@
+package team.startup.expo.domain.trainee.repository;
+
+import org.apache.commons.math3.analysis.function.Exp;
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.trainee.entity.Trainee;
+import team.startup.expo.domain.trainee.entity.TraineeParticipation;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface TraineeParticipationRepository extends JpaRepository<TraineeParticipation, Long> {
+    Optional<TraineeParticipation> findByExpoAndTraineeAndAttendanceDate(Expo expo, Trainee trainee, LocalDate attendanceDate);
+}

--- a/src/main/java/team/startup/expo/global/date/DateUtil.java
+++ b/src/main/java/team/startup/expo/global/date/DateUtil.java
@@ -1,0 +1,35 @@
+package team.startup.expo.global.date;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+@Component
+@Slf4j
+public class DateUtil {
+
+    public boolean dateComparison(String startDate, String endDate) {
+        try {
+            SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+
+            Date start = simpleDateFormat.parse(String.valueOf(startDate));
+            Date end = simpleDateFormat.parse(String.valueOf(endDate));
+            Date now = simpleDateFormat.parse(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+
+            log.info(startDate);
+            log.info(start.toString());
+            log.info(end.toString());
+            log.info(now.toString());
+
+            return !now.before(start) && !now.after(end);
+        } catch (ParseException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/src/main/java/team/startup/expo/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/expo/global/exception/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     NOT_FOUND_EXPO(404, "박람회를 찾지 못 했습니다."),
     NOT_EXIST_TRAINEE_AT_EXPO(404, "해당 박람회에 연수자가 존재하지 않습니다."),
     NOT_EXIST_PARTICIPANT_AT_EXPO(404, "해당 박람회에 관람객이 존재하지 않습니다."),
+    NOT_IN_PROGRESS_EXPO(400, "해당 박람회는 진행 중인 상태가 아닙니다."),
 
     // participant
     NOT_FOUND_PARTICIPANT(404, "행사 참가자를 찾지 못 했습니다."),


### PR DESCRIPTION
## 💡 배경 및 개요

박람회가 이틀이상 진행하는 경우 StandardParticipant와 Trainee 테이블에서 관리하기에는 유연성이 떨어지기 때문에 테이블을 하나 더 생성하여 입장하는 경우 체크할 수 있도록 설정하였습니다

Resolves: #183 

## 📃 작업내용

* StandardParticipantParticipation 관련 로직 추가
* TraineeParticipation 관련 로직 추가

## 🙋‍♂️ 리뷰노트

* 일반 프로그램 출석 N + 1 발생
* 연수 프로그램 출석 N + 1 발생

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타