### PR TITLE
🔀 :: 박람회 신청폼 불러오기 Path 수정

### DIFF
--- a/src/main/java/team/startup/expo/domain/form/presentation/FormController.java
+++ b/src/main/java/team/startup/expo/domain/form/presentation/FormController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import team.startup.expo.domain.form.entity.ParticipationType;
 import team.startup.expo.domain.form.presentation.dto.GetFormResponseDto;
 import team.startup.expo.domain.form.presentation.dto.request.FormRequestDto;
 import team.startup.expo.domain.form.service.CreateFormService;
@@ -40,9 +41,9 @@ public class FormController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @GetMapping("/{form_id}")
-    public ResponseEntity<GetFormResponseDto> getForm(@PathVariable("form_id") Long formId) {
-        GetFormResponseDto result = getFormService.execute(formId);
+    @GetMapping("/{expo_id}")
+    public ResponseEntity<GetFormResponseDto> getForm(@PathVariable("expo_id") String expoId, @RequestParam("type") ParticipationType participationType) {
+        GetFormResponseDto result = getFormService.execute(expoId, participationType);
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/team/startup/expo/domain/form/repository/FormRepository.java
+++ b/src/main/java/team/startup/expo/domain/form/repository/FormRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface FormRepository extends JpaRepository<Form, Long> {
     Optional<Form> findByExpo(Expo expo);
     Boolean existsByExpoAndParticipationType(Expo expo, ParticipationType participationType);
+    Optional<Form> findByExpoAndParticipationType(Expo expo, ParticipationType participationType);
 }

--- a/src/main/java/team/startup/expo/domain/form/service/GetFormService.java
+++ b/src/main/java/team/startup/expo/domain/form/service/GetFormService.java
@@ -1,7 +1,8 @@
 package team.startup.expo.domain.form.service;
 
+import team.startup.expo.domain.form.entity.ParticipationType;
 import team.startup.expo.domain.form.presentation.dto.GetFormResponseDto;
 
 public interface GetFormService {
-    GetFormResponseDto execute(Long formId);
+    GetFormResponseDto execute(String expoId, ParticipationType participationType);
 }

--- a/src/main/java/team/startup/expo/domain/form/service/impl/GetFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/GetFormServiceImpl.java
@@ -1,6 +1,9 @@
 package team.startup.expo.domain.form.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.expo.exception.NotFoundExpoException;
+import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.form.entity.DynamicForm;
 import team.startup.expo.domain.form.entity.Form;
 import team.startup.expo.domain.form.entity.ParticipationType;
@@ -18,10 +21,14 @@ import java.util.List;
 public class GetFormServiceImpl implements GetFormService {
 
     private final FormRepository formRepository;
+    private final ExpoRepository expoRepository;
     private final DynamicFormRepository dynamicFormRepository;
 
-    public GetFormResponseDto execute(Long formId) {
-        Form form = formRepository.findById(formId)
+    public GetFormResponseDto execute(String expoId, ParticipationType participationType) {
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(NotFoundExpoException::new);
+
+        Form form = formRepository.findByExpoAndParticipationType(expo, participationType)
                 .orElseThrow(NotFoundFormException::new);
 
         List<DynamicForm> dynamicFormList = dynamicFormRepository.findByForm(form);

--- a/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
@@ -131,7 +131,7 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.POST, "/form/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
                                 .requestMatchers(HttpMethod.PATCH, "/form/{form_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
                                 .requestMatchers(HttpMethod.DELETE, "/form/{form_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
-                                .requestMatchers(HttpMethod.GET, "/form/{form_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
+                                .requestMatchers(HttpMethod.GET, "/form/{expo_id}").permitAll()
 
                                 //image
                                 .requestMatchers(HttpMethod.POST, "/image").authenticated()


### PR DESCRIPTION
## 💡 배경 및 개요

박람회 신청폼을 불러오는 중에 Path를 formId로 설정하여 클라이언트가 알 수 있는 방법이 없어 expoId로 수정 후 파라미터를 추가로 받아 Trainee 혹은 Standard인지 받아 로직을 수정하였습니다

Resolves: #185 

## 📃 작업내용

* Path를 formId -> expoId로 변경
* Param으로 ParticipantType을 추가로 Request

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타