### PR TITLE
🔀 :: 연수자/일반 참가자 검색 api 기대한 검색결과 불일치 문제

### DIFF
--- a/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantRepository.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantRepository.java
@@ -1,6 +1,7 @@
 package team.startup.expo.domain.participant.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
@@ -11,6 +12,11 @@ import java.util.Optional;
 public interface StandardParticipantRepository extends JpaRepository<StandardParticipant, Long> {
     Optional<StandardParticipant> findByPhoneNumberAndExpo(String phoneNumber, Expo expo);
     void deleteByExpo(Expo expo);
+    @Query("SELECT sp FROM StandardParticipant sp " +
+            "JOIN sp.expo e " +
+            "WHERE e = :expo " +
+            "AND sp.applicationType = :applicationType " +
+            "AND sp.name LIKE %:name%")
     List<StandardParticipant> findByExpoAndApplicationTypeAndName(Expo expo, ApplicationType applicationType, String name);
     List<StandardParticipant> findByExpoAndApplicationType(Expo expo, ApplicationType applicationType);
     Boolean existsByPhoneNumberAndExpo(String phoneNumber, Expo expo);

--- a/src/main/java/team/startup/expo/domain/trainee/repository/TraineeRepository.java
+++ b/src/main/java/team/startup/expo/domain/trainee/repository/TraineeRepository.java
@@ -1,6 +1,7 @@
 package team.startup.expo.domain.trainee.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.trainee.entity.Trainee;
 
@@ -10,6 +11,10 @@ import java.util.Optional;
 public interface TraineeRepository extends JpaRepository<Trainee, Long> {
     Optional<Trainee> findByPhoneNumberAndExpo(String phoneNumber, Expo expo);
     List<Trainee> findByExpo(Expo expo);
+    @Query("SELECT t FROM Trainee t " +
+            "JOIN t.expo e " +
+            "WHERE e = :expo " +
+            "AND t.name LIKE %:name%")
     List<Trainee> findByExpoAndName(Expo expo, String name);
     void deleteByExpo(Expo expo);
     Boolean existsByPhoneNumberAndExpo(String phoneNumber, Expo expo);


### PR DESCRIPTION
## 💡 배경 및 개요

연수자 / 일반 참가자 검색 api를 사용하면 이름을 모두 검색해야 결과가 뜨는 문제가 있어 LIKE를 사용하여 한글자로도 검색이 될 수 있도록 수정하였습니다.

Resolves: #189 

## 📃 작업내용

* TraineeRepository에서 findByExpoAndName에 JPQL을 사용하여 쿼리 조회
* StandardParticipantRepository에서 findByExpoAndApplicationTypeAndName에 JPQL을 사용하여 쿼리 조회

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타