### PR TITLE
🔀 :: 박람회 설문조사 생성 api

### DIFF
--- a/src/main/java/team/startup/expo/domain/survey/entity/DynamicSurvey.java
+++ b/src/main/java/team/startup/expo/domain/survey/entity/DynamicSurvey.java
@@ -12,7 +12,7 @@ import team.startup.expo.domain.form.entity.FormType;
 @AllArgsConstructor
 @Builder
 @Getter
-@Table(name = "tb_standard_participant")
+@Table(name = "tb_dynamic_survey")
 public class DynamicSurvey {
 
     @Id

--- a/src/main/java/team/startup/expo/domain/survey/entity/Survey.java
+++ b/src/main/java/team/startup/expo/domain/survey/entity/Survey.java
@@ -20,7 +20,7 @@ public class Survey {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ParticipationType participationType;
 

--- a/src/main/java/team/startup/expo/domain/survey/exception/AlreadyExistSurveyException.java
+++ b/src/main/java/team/startup/expo/domain/survey/exception/AlreadyExistSurveyException.java
@@ -1,0 +1,10 @@
+package team.startup.expo.domain.survey.exception;
+
+import team.startup.expo.global.exception.ErrorCode;
+import team.startup.expo.global.exception.GlobalException;
+
+public class AlreadyExistSurveyException extends GlobalException {
+    public AlreadyExistSurveyException() {
+        super(ErrorCode.ALREADY_EXIST_SURVEY);
+    }
+}

--- a/src/main/java/team/startup/expo/domain/survey/presentation/SurveyController.java
+++ b/src/main/java/team/startup/expo/domain/survey/presentation/SurveyController.java
@@ -1,0 +1,23 @@
+package team.startup.expo.domain.survey.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import team.startup.expo.domain.survey.presentation.dto.request.SurveyRequestDto;
+import team.startup.expo.domain.survey.service.CreateSurveyService;
+
+@RestController
+@RequestMapping("/survey")
+@RequiredArgsConstructor
+public class SurveyController {
+
+    private final CreateSurveyService createSurveyService;
+
+    @PostMapping("/{expo_id}")
+    public ResponseEntity<Void> createSurvey(@PathVariable("expo_id") String expoId, @Valid @RequestBody SurveyRequestDto dto) {
+        createSurveyService.execute(expoId, dto);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/team/startup/expo/domain/survey/presentation/dto/request/SurveyRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/survey/presentation/dto/request/SurveyRequestDto.java
@@ -1,0 +1,37 @@
+package team.startup.expo.domain.survey.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.startup.expo.domain.form.entity.FormType;
+import team.startup.expo.domain.form.entity.ParticipationType;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class SurveyRequestDto {
+    @NotNull
+    private ParticipationType participationType;
+
+    @NotNull
+    private List<DynamicSurveyRequestDto> dynamicSurveyRequestDto;
+
+    @Getter
+    @NoArgsConstructor
+    public static class DynamicSurveyRequestDto {
+        @NotNull
+        private String title;
+
+        @NotNull
+        private String jsonData;
+
+        @NotNull
+        private FormType formType;
+
+        @NotNull
+        private Boolean requiredStatus;
+
+        private String otherJson;
+    }
+}

--- a/src/main/java/team/startup/expo/domain/survey/repository/DynamicSurveyRepository.java
+++ b/src/main/java/team/startup/expo/domain/survey/repository/DynamicSurveyRepository.java
@@ -1,0 +1,7 @@
+package team.startup.expo.domain.survey.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.startup.expo.domain.survey.entity.DynamicSurvey;
+
+public interface DynamicSurveyRepository extends JpaRepository<DynamicSurvey, Long> {
+}

--- a/src/main/java/team/startup/expo/domain/survey/repository/SurveyRepository.java
+++ b/src/main/java/team/startup/expo/domain/survey/repository/SurveyRepository.java
@@ -1,0 +1,10 @@
+package team.startup.expo.domain.survey.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.form.entity.ParticipationType;
+import team.startup.expo.domain.survey.entity.Survey;
+
+public interface SurveyRepository extends JpaRepository<Survey, Long> {
+    Boolean existsByExpoAndParticipationType(Expo expo, ParticipationType participationType);
+}

--- a/src/main/java/team/startup/expo/domain/survey/service/CreateSurveyService.java
+++ b/src/main/java/team/startup/expo/domain/survey/service/CreateSurveyService.java
@@ -1,0 +1,7 @@
+package team.startup.expo.domain.survey.service;
+
+import team.startup.expo.domain.survey.presentation.dto.request.SurveyRequestDto;
+
+public interface CreateSurveyService {
+    void execute(String expoId, SurveyRequestDto dto);
+}

--- a/src/main/java/team/startup/expo/domain/survey/service/impl/CreateSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/service/impl/CreateSurveyServiceImpl.java
@@ -1,0 +1,57 @@
+package team.startup.expo.domain.survey.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.expo.exception.NotFoundExpoException;
+import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.survey.entity.DynamicSurvey;
+import team.startup.expo.domain.survey.entity.Survey;
+import team.startup.expo.domain.survey.exception.AlreadyExistSurveyException;
+import team.startup.expo.domain.survey.presentation.dto.request.SurveyRequestDto;
+import team.startup.expo.domain.survey.repository.DynamicSurveyRepository;
+import team.startup.expo.domain.survey.repository.SurveyRepository;
+import team.startup.expo.domain.survey.service.CreateSurveyService;
+import team.startup.expo.global.annotation.TransactionService;
+
+@TransactionService
+@RequiredArgsConstructor
+public class CreateSurveyServiceImpl implements CreateSurveyService {
+
+    private final SurveyRepository surveyRepository;
+    private final DynamicSurveyRepository dynamicSurveyRepository;
+    private final ExpoRepository expoRepository;
+
+    public void execute(String expoId, SurveyRequestDto dto) {
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(NotFoundExpoException::new);
+
+        if (surveyRepository.existsByExpoAndParticipationType(expo, dto.getParticipationType()))
+            throw new AlreadyExistSurveyException();
+
+        Survey survey = saveSurvey(dto, expo);
+
+        dto.getDynamicSurveyRequestDto().forEach(dynamicSurveyRequestDto -> saveDynamicSurvey(dynamicSurveyRequestDto, survey));
+    }
+
+    private Survey saveSurvey(SurveyRequestDto dto, Expo expo) {
+        Survey survey = Survey.builder()
+                .participationType(dto.getParticipationType())
+                .expo(expo)
+                .build();
+
+        return surveyRepository.save(survey);
+    }
+
+    private void saveDynamicSurvey(SurveyRequestDto.DynamicSurveyRequestDto dto, Survey survey) {
+        DynamicSurvey dynamicSurvey = DynamicSurvey.builder()
+                .title(dto.getTitle())
+                .jsonData(dto.getJsonData())
+                .formType(dto.getFormType())
+                .requiredStatus(dto.getRequiredStatus())
+                .otherJson(dto.getOtherJson())
+                .survey(survey)
+                .build();
+
+        dynamicSurveyRepository.save(dynamicSurvey);
+    }
+}

--- a/src/main/java/team/startup/expo/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/expo/global/exception/ErrorCode.java
@@ -62,6 +62,9 @@ public enum ErrorCode {
     ALREADY_EXIST_FORM(409, "이미 폼이 존재합니다."),
     NOT_FOUND_FORM(404, "폼을 찾을 수 없습니다."),
 
+    // survey
+    ALREADY_EXIST_SURVEY(409, "이미 설문조사 폼이 존재합니다."),
+
     // server
     INTERNAL_SERVER_ERROR(500, "예기치 못한 서버 에러");
 

--- a/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
@@ -134,6 +134,9 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.DELETE, "/form/{form_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
                                 .requestMatchers(HttpMethod.GET, "/form/{expo_id}").permitAll()
 
+                                // survey
+                                .requestMatchers(HttpMethod.POST, "/survey/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
+
                                 //image
                                 .requestMatchers(HttpMethod.POST, "/image").authenticated()
 


### PR DESCRIPTION
## 💡 배경 및 개요

박람회 참여 후 설문조사를 받기 위한 폼 생성 api를 추가하였습니다

Resolves: #195 

## 📃 작업내용

* CreateSurvey api 추가
* Survey 엔티티 Enum 저장 타입 정하기 위해 어노테이션 추가

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타