### PR TITLE
🔀 :: 박람회 설문조사 폼 수정

### DIFF
--- a/src/main/java/team/startup/expo/domain/survey/presentation/SurveyController.java
+++ b/src/main/java/team/startup/expo/domain/survey/presentation/SurveyController.java
@@ -10,6 +10,7 @@ import team.startup.expo.domain.survey.presentation.dto.request.SurveyRequestDto
 import team.startup.expo.domain.survey.presentation.dto.response.SurveyResponseDto;
 import team.startup.expo.domain.survey.service.CreateSurveyService;
 import team.startup.expo.domain.survey.service.GetSurveyService;
+import team.startup.expo.domain.survey.service.UpdateSurveyService;
 
 @RestController
 @RequestMapping("/survey")
@@ -18,6 +19,7 @@ public class SurveyController {
 
     private final CreateSurveyService createSurveyService;
     private final GetSurveyService getSurveyService;
+    private final UpdateSurveyService updateSurveyService;
 
     @PostMapping("/{expo_id}")
     public ResponseEntity<Void> createSurvey(@PathVariable("expo_id") String expoId, @Valid @RequestBody SurveyRequestDto dto) {
@@ -29,5 +31,11 @@ public class SurveyController {
     public ResponseEntity<SurveyResponseDto> getSurvey(@PathVariable("expo_id") String expoId, @RequestParam("type")ParticipationType participationType) {
         SurveyResponseDto response = getSurveyService.execute(expoId, participationType);
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{expo_id}")
+    public ResponseEntity<Void> updateSurvey(@PathVariable("expo_id") String expoId, @Valid @RequestBody SurveyRequestDto dto) {
+        updateSurveyService.execute(expoId, dto);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/team/startup/expo/domain/survey/presentation/dto/response/SurveyResponseDto.java
+++ b/src/main/java/team/startup/expo/domain/survey/presentation/dto/response/SurveyResponseDto.java
@@ -1,6 +1,5 @@
 package team.startup.expo.domain.survey.presentation.dto.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import team.startup.expo.domain.form.entity.FormType;

--- a/src/main/java/team/startup/expo/domain/survey/repository/DynamicSurveyRepository.java
+++ b/src/main/java/team/startup/expo/domain/survey/repository/DynamicSurveyRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface DynamicSurveyRepository extends JpaRepository<DynamicSurvey, Long> {
     List<DynamicSurvey> findBySurvey(Survey survey);
+    void deleteBySurvey(Survey survey);
 }

--- a/src/main/java/team/startup/expo/domain/survey/service/UpdateSurveyService.java
+++ b/src/main/java/team/startup/expo/domain/survey/service/UpdateSurveyService.java
@@ -1,0 +1,7 @@
+package team.startup.expo.domain.survey.service;
+
+import team.startup.expo.domain.survey.presentation.dto.request.SurveyRequestDto;
+
+public interface UpdateSurveyService {
+    void execute(String expoId, SurveyRequestDto dto);
+}

--- a/src/main/java/team/startup/expo/domain/survey/service/impl/UpdateSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/service/impl/UpdateSurveyServiceImpl.java
@@ -1,0 +1,47 @@
+package team.startup.expo.domain.survey.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.expo.exception.NotFoundExpoException;
+import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.survey.entity.DynamicSurvey;
+import team.startup.expo.domain.survey.entity.Survey;
+import team.startup.expo.domain.survey.exception.NotFoundSurveyException;
+import team.startup.expo.domain.survey.presentation.dto.request.SurveyRequestDto;
+import team.startup.expo.domain.survey.repository.DynamicSurveyRepository;
+import team.startup.expo.domain.survey.repository.SurveyRepository;
+import team.startup.expo.domain.survey.service.UpdateSurveyService;
+import team.startup.expo.global.annotation.TransactionService;
+
+@TransactionService
+@RequiredArgsConstructor
+public class UpdateSurveyServiceImpl implements UpdateSurveyService {
+
+    private final SurveyRepository surveyRepository;
+    private final DynamicSurveyRepository dynamicSurveyRepository;
+    private final ExpoRepository expoRepository;
+
+    public void execute(String expoId, SurveyRequestDto dto) {
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(NotFoundExpoException::new);
+
+        Survey survey = surveyRepository.findByExpoAndParticipationType(expo, dto.getParticipationType())
+                .orElseThrow(NotFoundSurveyException::new);
+
+        dynamicSurveyRepository.deleteBySurvey(survey);
+        dto.getDynamicSurveyRequestDto().forEach(dynamicSurveyRequestDto -> saveDynamicSurvey(dynamicSurveyRequestDto, survey));
+    }
+
+    private void saveDynamicSurvey(SurveyRequestDto.DynamicSurveyRequestDto dto, Survey survey) {
+        DynamicSurvey dynamicSurvey = DynamicSurvey.builder()
+                .title(dto.getTitle())
+                .jsonData(dto.getJsonData())
+                .formType(dto.getFormType())
+                .requiredStatus(dto.getRequiredStatus())
+                .otherJson(dto.getOtherJson())
+                .survey(survey)
+                .build();
+
+        dynamicSurveyRepository.save(dynamicSurvey);
+    }
+}

--- a/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
@@ -137,6 +137,7 @@ public class SecurityConfig {
                                 // survey
                                 .requestMatchers(HttpMethod.POST, "/survey/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
                                 .requestMatchers(HttpMethod.GET, "/survey/{expo_id}").permitAll()
+                                .requestMatchers(HttpMethod.PATCH, "/survey/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
 
                                 //image
                                 .requestMatchers(HttpMethod.POST, "/image").authenticated()


### PR DESCRIPTION
## 💡 배경 및 개요

박람회 설문조사 폼 수정할 수 있는 api를 추가하였습니다

Resolves: #198 

## 📃 작업내용

* UpdateSurvey api 추가

## 🙋‍♂️ 리뷰노트

수정하는 과정에서 하나하나 바꾸기 힘들어 DynamicSurvey에 존재하는 데이터를 지우고 추가하는 과정에서 총 8개의 쿼리가 보내져 나중에 최적화하는 편이 좋을 것 같습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타