### PR TITLE
🔀 :: 박람회 설문조사 삭제

### DIFF
--- a/src/main/java/team/startup/expo/domain/survey/presentation/SurveyController.java
+++ b/src/main/java/team/startup/expo/domain/survey/presentation/SurveyController.java
@@ -9,6 +9,7 @@ import team.startup.expo.domain.form.entity.ParticipationType;
 import team.startup.expo.domain.survey.presentation.dto.request.SurveyRequestDto;
 import team.startup.expo.domain.survey.presentation.dto.response.SurveyResponseDto;
 import team.startup.expo.domain.survey.service.CreateSurveyService;
+import team.startup.expo.domain.survey.service.DeleteSurveyService;
 import team.startup.expo.domain.survey.service.GetSurveyService;
 import team.startup.expo.domain.survey.service.UpdateSurveyService;
 
@@ -20,6 +21,7 @@ public class SurveyController {
     private final CreateSurveyService createSurveyService;
     private final GetSurveyService getSurveyService;
     private final UpdateSurveyService updateSurveyService;
+    private final DeleteSurveyService deleteSurveyService;
 
     @PostMapping("/{expo_id}")
     public ResponseEntity<Void> createSurvey(@PathVariable("expo_id") String expoId, @Valid @RequestBody SurveyRequestDto dto) {
@@ -36,6 +38,12 @@ public class SurveyController {
     @PatchMapping("/{expo_id}")
     public ResponseEntity<Void> updateSurvey(@PathVariable("expo_id") String expoId, @Valid @RequestBody SurveyRequestDto dto) {
         updateSurveyService.execute(expoId, dto);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{expo_id}")
+    public ResponseEntity<Void> deleteSurvey(@PathVariable("expo_id") String expoId) {
+        deleteSurveyService.execute(expoId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/team/startup/expo/domain/survey/repository/SurveyRepository.java
+++ b/src/main/java/team/startup/expo/domain/survey/repository/SurveyRepository.java
@@ -5,9 +5,11 @@ import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.form.entity.ParticipationType;
 import team.startup.expo.domain.survey.entity.Survey;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
     Boolean existsByExpoAndParticipationType(Expo expo, ParticipationType participationType);
     Optional<Survey> findByExpoAndParticipationType(Expo expo, ParticipationType participationType);
+    List<Survey> findByExpo(Expo expo);
 }

--- a/src/main/java/team/startup/expo/domain/survey/service/DeleteSurveyService.java
+++ b/src/main/java/team/startup/expo/domain/survey/service/DeleteSurveyService.java
@@ -1,0 +1,5 @@
+package team.startup.expo.domain.survey.service;
+
+public interface DeleteSurveyService {
+    void execute(String expoId);
+}

--- a/src/main/java/team/startup/expo/domain/survey/service/impl/DeleteSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/service/impl/DeleteSurveyServiceImpl.java
@@ -1,0 +1,33 @@
+package team.startup.expo.domain.survey.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.expo.exception.NotFoundExpoException;
+import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.survey.entity.Survey;
+import team.startup.expo.domain.survey.exception.NotFoundSurveyException;
+import team.startup.expo.domain.survey.repository.DynamicSurveyRepository;
+import team.startup.expo.domain.survey.repository.SurveyRepository;
+import team.startup.expo.domain.survey.service.DeleteSurveyService;
+import team.startup.expo.global.annotation.TransactionService;
+
+import java.util.List;
+
+@TransactionService
+@RequiredArgsConstructor
+public class DeleteSurveyServiceImpl implements DeleteSurveyService {
+
+    private final SurveyRepository surveyRepository;
+    private final DynamicSurveyRepository dynamicSurveyRepository;
+    private final ExpoRepository expoRepository;
+
+    public void execute(String expoId) {
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(NotFoundExpoException::new);
+
+        List<Survey> surveyList = surveyRepository.findByExpo(expo);
+
+        surveyList.forEach(dynamicSurveyRepository::deleteBySurvey);
+        surveyRepository.deleteAll(surveyList);
+    }
+}

--- a/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
@@ -138,6 +138,7 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.POST, "/survey/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
                                 .requestMatchers(HttpMethod.GET, "/survey/{expo_id}").permitAll()
                                 .requestMatchers(HttpMethod.PATCH, "/survey/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
+                                .requestMatchers(HttpMethod.DELETE, "/survey/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
 
                                 //image
                                 .requestMatchers(HttpMethod.POST, "/image").authenticated()


### PR DESCRIPTION
## 💡 배경 및 개요

박람회 설문조사 폼을 삭제할 수 있는 api를 추가하겠습니다

Resolves: #199 

## 📃 작업내용

* DeleteSurvey api 추가

## 🙋‍♂️ 리뷰노트

박람회 설문조사에서 DynamicSurvey가 늘어날 수록 쿼리가 많아질 것으로 예상됩니다.
테스트에서 각각 일반과 연수를 나눠서 2개씩 데이터를 넣어 테스트한 결과 약 11개의 쿼리가 발생하였습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타