### PR TITLE
🔀 :: 박람회 삭제 500 문제 해결

### DIFF
--- a/src/main/java/team/startup/expo/domain/expo/entity/Expo.java
+++ b/src/main/java/team/startup/expo/domain/expo/entity/Expo.java
@@ -42,8 +42,4 @@ public class Expo {
 
     @Column(nullable = false, columnDefinition = "VARCHAR(15)")
     private String y;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "admin_id")
-    private Admin admin;
 }

--- a/src/main/java/team/startup/expo/domain/expo/presentation/dto/request/UpdateExpoRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/expo/presentation/dto/request/UpdateExpoRequestDto.java
@@ -12,7 +12,6 @@ import team.startup.expo.domain.training.presentation.dto.request.AddTrainingPro
 import team.startup.expo.domain.training.presentation.dto.request.UpdateTrainingProRequestDto;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -62,7 +61,6 @@ public class UpdateExpoRequestDto {
                 .coverImage(coverImage)
                 .x(x)
                 .y(y)
-                .admin(expo.getAdmin())
                 .build();
     }
 }

--- a/src/main/java/team/startup/expo/domain/expo/service/impl/DeleteExpoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/impl/DeleteExpoServiceImpl.java
@@ -1,24 +1,17 @@
 package team.startup.expo.domain.expo.service.impl;
 
 import lombok.RequiredArgsConstructor;
-import team.startup.expo.domain.admin.entity.Admin;
-import team.startup.expo.domain.admin.util.UserUtil;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
-import team.startup.expo.domain.expo.exception.NotMatchAdminException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.expo.service.DeleteExpoService;
+import team.startup.expo.domain.form.repository.FormRepository;
 import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
-import team.startup.expo.domain.standard.entity.StandardProgram;
 import team.startup.expo.domain.standard.repository.StandardProgramRepository;
-import team.startup.expo.domain.standard.repository.StandardProgramUserRepository;
+import team.startup.expo.domain.survey.management.repository.SurveyRepository;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
-import team.startup.expo.domain.training.entity.TrainingProgram;
 import team.startup.expo.domain.training.repository.TrainingProgramRepository;
-import team.startup.expo.domain.training.repository.TrainingProgramUserRepository;
 import team.startup.expo.global.annotation.TransactionService;
-
-import java.util.List;
 
 @TransactionService
 @RequiredArgsConstructor
@@ -26,35 +19,50 @@ public class DeleteExpoServiceImpl implements DeleteExpoService {
 
     private final ExpoRepository expoRepository;
     private final StandardProgramRepository standardProgramRepository;
-    private final StandardProgramUserRepository standardProgramUserRepository;
-    private final TrainingProgramUserRepository trainingProgramUserRepository;
     private final StandardParticipantRepository standardParticipantRepository;
     private final TraineeRepository traineeRepository;
     private final TrainingProgramRepository trainingProgramRepository;
-    private final UserUtil userUtil;
+    private final FormRepository formRepository;
+    private final SurveyRepository surveyRepository;
 
     public void execute(String expoId) {
-        Admin admin = userUtil.getCurrentUser();
-
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
-        if (expo.getAdmin() != admin) {
-            throw new NotMatchAdminException();
-        }
+        deleteTrainingProgram(expo);
+        deleteStandardProgram(expo);
+        deleteForm(expo);
+        deleteSurvey(expo);
+        deleteStandardParticipant(expo);
+        deleteTrainee(expo);
+        deleteExpo(expoId);
+    }
 
-        List<TrainingProgram> trainingPrograms = trainingProgramRepository.findByExpo(expo);
-
-        trainingPrograms.forEach(trainingProgramUserRepository::deleteByTrainingProgram);
-
-        List<StandardProgram> standardPrograms = standardProgramRepository.findByExpo(expo);
-
-        standardPrograms.forEach(standardProgramUserRepository::deleteByStandardProgram);
-
-        standardProgramRepository.deleteByExpo(expo);
+    private void deleteTrainingProgram(Expo expo) {
         trainingProgramRepository.deleteByExpo(expo);
+    }
+
+    private void deleteStandardProgram(Expo expo) {
+        standardProgramRepository.deleteByExpo(expo);
+    }
+
+    private void deleteStandardParticipant(Expo expo) {
         standardParticipantRepository.deleteByExpo(expo);
+    }
+
+    private void deleteTrainee(Expo expo) {
         traineeRepository.deleteByExpo(expo);
-        expoRepository.delete(expo);
+    }
+
+    private void deleteForm(Expo expo) {
+        formRepository.deleteByExpo(expo);
+    }
+
+    private void deleteSurvey(Expo expo) {
+        surveyRepository.deleteByExpo(expo);
+    }
+
+    private void deleteExpo(String expoId) {
+        expoRepository.deleteById(expoId);
     }
 }

--- a/src/main/java/team/startup/expo/domain/expo/service/impl/GenerateExpoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/impl/GenerateExpoServiceImpl.java
@@ -24,14 +24,11 @@ import java.util.List;
 public class GenerateExpoServiceImpl implements GenerateExpoService {
 
     private final ExpoRepository expoRepository;
-    private final UserUtil userUtil;
     private final StandardProgramRepository standardProgramRepository;
     private final TrainingProgramRepository trainingProgramRepository;
 
     public GenerateExpoResponseDto execute(GenerateExpoRequestDto dto) {
-        Admin admin = userUtil.getCurrentUser();
-
-        Expo expo = saveExpo(dto, admin);
+        Expo expo = saveExpo(dto);
 
         dto.getAddStandardProRequestDto().forEach(addStandardProRequestDto -> {saveStandardPro(addStandardProRequestDto, expo);});
         dto.getAddTrainingProRequestDto().forEach(addTrainingProRequestDto -> {saveTrainingPro(addTrainingProRequestDto, expo);});
@@ -41,7 +38,7 @@ public class GenerateExpoServiceImpl implements GenerateExpoService {
                 .build();
     }
 
-    private Expo saveExpo(GenerateExpoRequestDto dto, Admin admin) {
+    private Expo saveExpo(GenerateExpoRequestDto dto) {
         Expo expo = Expo.builder()
                 .id(ULIDGenerator.generateULID())
                 .title(dto.getTitle())
@@ -52,7 +49,6 @@ public class GenerateExpoServiceImpl implements GenerateExpoService {
                 .coverImage(dto.getCoverImage())
                 .x(dto.getX())
                 .y(dto.getY())
-                .admin(admin)
                 .build();
 
         expoRepository.save(expo);

--- a/src/main/java/team/startup/expo/domain/expo/service/impl/UpdateExpoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/impl/UpdateExpoServiceImpl.java
@@ -1,20 +1,16 @@
 package team.startup.expo.domain.expo.service.impl;
 
 import lombok.RequiredArgsConstructor;
-import team.startup.expo.domain.admin.entity.Admin;
 import team.startup.expo.domain.admin.util.UserUtil;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
-import team.startup.expo.domain.expo.exception.NotMatchAdminException;
 import team.startup.expo.domain.expo.presentation.dto.request.UpdateExpoRequestDto;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.expo.service.UpdateExpoService;
 import team.startup.expo.domain.standard.entity.StandardProgram;
-import team.startup.expo.domain.standard.presentation.dto.request.AddStandardProRequestDto;
 import team.startup.expo.domain.standard.presentation.dto.request.UpdateStandardProRequestDto;
 import team.startup.expo.domain.standard.repository.StandardProgramRepository;
 import team.startup.expo.domain.training.entity.TrainingProgram;
-import team.startup.expo.domain.training.presentation.dto.request.AddTrainingProRequestDto;
 import team.startup.expo.domain.training.presentation.dto.request.UpdateTrainingProRequestDto;
 import team.startup.expo.domain.training.repository.TrainingProgramRepository;
 import team.startup.expo.global.annotation.TransactionService;
@@ -24,18 +20,12 @@ import team.startup.expo.global.annotation.TransactionService;
 public class UpdateExpoServiceImpl implements UpdateExpoService {
 
     private final ExpoRepository expoRepository;
-    private final UserUtil userUtil;
     private final StandardProgramRepository standardProgramRepository;
     private final TrainingProgramRepository trainingProgramRepository;
 
     public void execute(String expoId, UpdateExpoRequestDto dto) {
-        Admin admin = userUtil.getCurrentUser();
-
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
-
-        if (expo.getAdmin() != admin)
-            throw new NotMatchAdminException();
 
         dto.getUpdateStandardProRequestDto().forEach(updateStandardProRequestDto -> {saveStandardPro(updateStandardProRequestDto, expo);});
         dto.getUpdateTrainingProRequestDto().forEach(updateTrainingProRequestDto -> {saveTrainingPro(updateTrainingProRequestDto, expo);});

--- a/src/main/java/team/startup/expo/domain/form/entity/DynamicForm.java
+++ b/src/main/java/team/startup/expo/domain/form/entity/DynamicForm.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @NoArgsConstructor
@@ -36,5 +38,6 @@ public class DynamicForm {
 
     @JoinColumn(name = "form_id")
     @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Form form;
 }

--- a/src/main/java/team/startup/expo/domain/form/entity/Form.java
+++ b/src/main/java/team/startup/expo/domain/form/entity/Form.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.form.presentation.dto.request.FormRequestDto;
 
@@ -29,6 +31,7 @@ public class Form {
 
     @ManyToOne
     @JoinColumn(name = "expo_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Expo expo;
 
     public void updateForm(FormRequestDto dto) {

--- a/src/main/java/team/startup/expo/domain/form/repository/FormRepository.java
+++ b/src/main/java/team/startup/expo/domain/form/repository/FormRepository.java
@@ -5,10 +5,12 @@ import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.form.entity.Form;
 import team.startup.expo.domain.form.entity.ParticipationType;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FormRepository extends JpaRepository<Form, Long> {
-    Optional<Form> findByExpo(Expo expo);
+    List<Form> findByExpo(Expo expo);
     Boolean existsByExpoAndParticipationType(Expo expo, ParticipationType participationType);
     Optional<Form> findByExpoAndParticipationType(Expo expo, ParticipationType participationType);
+    void deleteByExpo(Expo expo);
 }

--- a/src/main/java/team/startup/expo/domain/participant/entity/StandardParticipant.java
+++ b/src/main/java/team/startup/expo/domain/participant/entity/StandardParticipant.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.admin.entity.Authority;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
@@ -47,6 +49,7 @@ public class StandardParticipant {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "expo_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Expo expo;
 
     public void addQrCode(byte[] qrCode) {

--- a/src/main/java/team/startup/expo/domain/participant/entity/StandardParticipantParticipation.java
+++ b/src/main/java/team/startup/expo/domain/participant/entity/StandardParticipantParticipation.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.expo.entity.Expo;
 
 import java.time.LocalDate;
@@ -33,10 +35,12 @@ public class StandardParticipantParticipation {
 
     @JoinColumn(name = "standard_participant_id")
     @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private StandardParticipant standardParticipant;
 
     @JoinColumn(name = "expo_id")
     @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Expo expo;
 
     public void addLeaveTime() {

--- a/src/main/java/team/startup/expo/domain/standard/entity/StandardProgram.java
+++ b/src/main/java/team/startup/expo/domain/standard/entity/StandardProgram.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.expo.entity.Expo;
 
 @Entity
@@ -30,6 +32,7 @@ public class StandardProgram {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "expo_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Expo expo;
 
 }

--- a/src/main/java/team/startup/expo/domain/standard/entity/StandardProgramUser.java
+++ b/src/main/java/team/startup/expo/domain/standard/entity/StandardProgramUser.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 
 @Entity
@@ -30,10 +32,12 @@ public class StandardProgramUser {
 
     @ManyToOne
     @JoinColumn(name = "standardPro_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private StandardProgram standardProgram;
 
     @ManyToOne
     @JoinColumn(name = "standard_participant_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private StandardParticipant standardParticipant;
 
     public void addLeaveTime(String leaveTime) {

--- a/src/main/java/team/startup/expo/domain/survey/answer/entity/StandardParticipantSurveyAnswer.java
+++ b/src/main/java/team/startup/expo/domain/survey/answer/entity/StandardParticipantSurveyAnswer.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 
 @Entity
@@ -24,5 +26,6 @@ public class StandardParticipantSurveyAnswer {
 
     @ManyToOne
     @JoinColumn(name = "standard_participant_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private StandardParticipant standardParticipant;
 }

--- a/src/main/java/team/startup/expo/domain/survey/answer/entity/TraineeSurveyAnswer.java
+++ b/src/main/java/team/startup/expo/domain/survey/answer/entity/TraineeSurveyAnswer.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.trainee.entity.Trainee;
 
 @Entity
@@ -24,5 +26,6 @@ public class TraineeSurveyAnswer {
 
     @ManyToOne
     @JoinColumn(name = "trainee_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Trainee trainee;
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/entity/DynamicSurvey.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/entity/DynamicSurvey.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.form.entity.FormType;
 
 @Entity
@@ -37,5 +39,6 @@ public class DynamicSurvey {
 
     @ManyToOne
     @JoinColumn(name = "survey_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Survey survey;
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/entity/Survey.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/entity/Survey.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.form.entity.ParticipationType;
 
@@ -26,5 +28,6 @@ public class Survey {
 
     @ManyToOne
     @JoinColumn(name = "expo_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Expo expo;
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/repository/DynamicSurveyRepository.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/repository/DynamicSurveyRepository.java
@@ -1,6 +1,8 @@
 package team.startup.expo.domain.survey.management.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import team.startup.expo.domain.survey.management.entity.DynamicSurvey;
 import team.startup.expo.domain.survey.management.entity.Survey;
 
@@ -8,5 +10,8 @@ import java.util.List;
 
 public interface DynamicSurveyRepository extends JpaRepository<DynamicSurvey, Long> {
     List<DynamicSurvey> findBySurvey(Survey survey);
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE DynamicSurvey ds WHERE ds.survey IN :surveys")
+    void deleteBySurveys(List<Survey> surveys);
     void deleteBySurvey(Survey survey);
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/repository/SurveyRepository.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/repository/SurveyRepository.java
@@ -12,4 +12,5 @@ public interface SurveyRepository extends JpaRepository<Survey, Long> {
     Boolean existsByExpoAndParticipationType(Expo expo, ParticipationType participationType);
     Optional<Survey> findByExpoAndParticipationType(Expo expo, ParticipationType participationType);
     List<Survey> findByExpo(Expo expo);
+    void deleteByExpo(Expo expo);
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/service/impl/DeleteSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/impl/DeleteSurveyServiceImpl.java
@@ -26,7 +26,7 @@ public class DeleteSurveyServiceImpl implements DeleteSurveyService {
 
         List<Survey> surveyList = surveyRepository.findByExpo(expo);
 
-        surveyList.forEach(dynamicSurveyRepository::deleteBySurvey);
+        dynamicSurveyRepository.deleteBySurveys(surveyList);
         surveyRepository.deleteAll(surveyList);
     }
 }

--- a/src/main/java/team/startup/expo/domain/trainee/entity/Trainee.java
+++ b/src/main/java/team/startup/expo/domain/trainee/entity/Trainee.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.admin.entity.Authority;
 import team.startup.expo.domain.expo.entity.Expo;
 
@@ -49,6 +51,7 @@ public class Trainee {
 
     @ManyToOne
     @JoinColumn(name = "expo_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Expo expo;
 
     public void addQrCode(byte[] qrCode) {

--- a/src/main/java/team/startup/expo/domain/trainee/entity/TraineeParticipation.java
+++ b/src/main/java/team/startup/expo/domain/trainee/entity/TraineeParticipation.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.expo.entity.Expo;
 
 import java.time.LocalDate;
@@ -33,10 +35,12 @@ public class TraineeParticipation {
 
     @JoinColumn(name = "trainee_id")
     @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Trainee trainee;
 
     @JoinColumn(name = "expo_id")
     @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Expo expo;
 
     public void addLeaveTime() {

--- a/src/main/java/team/startup/expo/domain/trainee/repository/TraineeParticipationRepository.java
+++ b/src/main/java/team/startup/expo/domain/trainee/repository/TraineeParticipationRepository.java
@@ -1,6 +1,5 @@
 package team.startup.expo.domain.trainee.repository;
 
-import org.apache.commons.math3.analysis.function.Exp;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.trainee.entity.Trainee;

--- a/src/main/java/team/startup/expo/domain/training/entity/TrainingProgram.java
+++ b/src/main/java/team/startup/expo/domain/training/entity/TrainingProgram.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.expo.entity.Expo;
 
 @Entity
@@ -34,5 +36,6 @@ public class TrainingProgram {
 
     @ManyToOne
     @JoinColumn(name = "expo_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Expo expo;
 }

--- a/src/main/java/team/startup/expo/domain/training/entity/TrainingProgramUser.java
+++ b/src/main/java/team/startup/expo/domain/training/entity/TrainingProgramUser.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.trainee.entity.Trainee;
 
 @Entity
@@ -30,13 +32,11 @@ public class TrainingProgramUser {
 
     @ManyToOne
     @JoinColumn(name = "trainingPro_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private TrainingProgram trainingProgram;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trainee_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Trainee trainee;
-
-    public void addLeaveTime(String leaveTime) {
-        this.leaveTime = leaveTime;
-    }
 }

--- a/src/main/java/team/startup/expo/domain/training/service/impl/AddTrainingProServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/training/service/impl/AddTrainingProServiceImpl.java
@@ -19,16 +19,10 @@ public class AddTrainingProServiceImpl implements AddTrainingProService {
 
     private final ExpoRepository expoRepository;
     private final TrainingProgramRepository trainingProgramRepository;
-    private final UserUtil userUtil;
 
     public void execute(String expoId, AddTrainingProRequestDto dto) {
-        Admin admin = userUtil.getCurrentUser();
-
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
-
-        if (expo.getAdmin() != admin)
-            throw new NotMatchAdminException();
 
         saveTrainingPro(dto, expo);
     }


### PR DESCRIPTION
## 💡 배경 및 개요

박람회 삭제를 초반에 만들어 뒤에 들어난 Expo와 연관관계가 있는 엔티티가 삭제되지 않아 외래키 제약조건이 발생하는 문제를 해결하였습니다.

Resolves: #205 

## 📃 작업내용

* JPQL으로 몇몇 쿼리 최적화
* DeleteExpo api 수정

## 🙋‍♂️ 리뷰노트

테스트 시에 프로그램 일반/연수 2개씩과 프로그램 안에 참가자 2씩넣고 다른 데이터들도 2개씩 넣어 테스트결과 41개의 쿼리가 발생하였습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타