### PR TITLE
🔀 :: 박람회 입장 조건문 추가

### DIFF
--- a/src/main/java/team/startup/expo/domain/attendance/service/impl/PreEnterScanQrCodeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/attendance/service/impl/PreEnterScanQrCodeServiceImpl.java
@@ -1,6 +1,7 @@
 package team.startup.expo.domain.attendance.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import team.startup.expo.domain.attendance.exception.AlreadyEnterExpoUserException;
 import team.startup.expo.domain.attendance.presentation.dto.request.PreEnterScanQrCodeRequestDto;
 import team.startup.expo.domain.attendance.presentation.dto.response.PreEnterScanQrCodeResponseDto;
 import team.startup.expo.domain.attendance.service.PreEnterScanQrCodeService;
@@ -63,6 +64,10 @@ public class PreEnterScanQrCodeServiceImpl implements PreEnterScanQrCodeService 
 
         if (standardParticipantParticipation.isPresent()) {
             StandardParticipantParticipation getStandardParticipantParticipation = standardParticipantParticipation.get();
+
+            if (getStandardParticipantParticipation.getLeaveTime() != null)
+                throw new AlreadyEnterExpoUserException();
+
             getStandardParticipantParticipation.addLeaveTime();
         } else {
             StandardParticipantParticipation newStandardParticipantParticipation = StandardParticipantParticipation.builder()
@@ -91,6 +96,10 @@ public class PreEnterScanQrCodeServiceImpl implements PreEnterScanQrCodeService 
 
         if (traineeParticipation.isPresent()) {
             TraineeParticipation getTraineeParticipation = traineeParticipation.get();
+
+            if (getTraineeParticipation.getLeaveTime() != null)
+                throw new AlreadyEnterExpoUserException();
+
             getTraineeParticipation.addLeaveTime();
         } else {
             TraineeParticipation newTraineeParticipation = TraineeParticipation.builder()


### PR DESCRIPTION
## 💡 배경 및 개요

박람회 입장 후 퇴장 시에 여러번 찍혀 퇴장시간이 바뀌는 상황이 있어 이미 퇴장하였다면 에러가 뜨게 핸들링하였습니다

Resolves: #211 

## 📃 작업내용

* 퇴장되었다면 에러가 뜨게 핸들링 처리

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타