### PR TITLE
🔀 :: 박람회 수정이 올바르게 진행되지 않는 문제

### DIFF
--- a/src/main/java/team/startup/expo/domain/expo/service/impl/UpdateExpoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/expo/service/impl/UpdateExpoServiceImpl.java
@@ -27,8 +27,11 @@ public class UpdateExpoServiceImpl implements UpdateExpoService {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
-        dto.getUpdateStandardProRequestDto().forEach(updateStandardProRequestDto -> {saveStandardPro(updateStandardProRequestDto, expo);});
-        dto.getUpdateTrainingProRequestDto().forEach(updateTrainingProRequestDto -> {saveTrainingPro(updateTrainingProRequestDto, expo);});
+        standardProgramRepository.deleteByExpo(expo);
+        trainingProgramRepository.deleteByExpo(expo);
+
+        dto.getUpdateStandardProRequestDto().forEach(standardProRequestDto -> saveStandardPro(standardProRequestDto, expo));
+        dto.getUpdateTrainingProRequestDto().forEach(trainingProRequestDto -> saveTrainingPro(trainingProRequestDto, expo));
 
         expoRepository.save(dto.toEntity(expo));
     }


### PR DESCRIPTION
## 💡 배경 및 개요

박람회를 수정하며 로직에서 프로그램을 해당 id로 찾아 수정하는 로직이였지만 그렇게 수정한다면 원래 있던것은 수정이 되지만 새로 추가하며 id가 바껴 올바르게 수정되지 않는 문제를 해결하였습니다

Resolves: #229 

## 📃 작업내용

* 프로그램을 하나하나씩 하는 것이 아닌 해당 Expo로 연관관계 매핑되어 있는 엔티티를 찾아 삭제 후 새로 추가하는 방식으로 수정하였습니다

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타