### PR TITLE
🔀 :: sms 문자 발송 비동기 설정

### DIFF
--- a/src/main/java/team/startup/expo/ExpoApplication.java
+++ b/src/main/java/team/startup/expo/ExpoApplication.java
@@ -4,9 +4,11 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 import java.util.TimeZone;
 
+@EnableAsync
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class ExpoApplication {

--- a/src/main/java/team/startup/expo/domain/sms/event/handler/SendQrEventHandler.java
+++ b/src/main/java/team/startup/expo/domain/sms/event/handler/SendQrEventHandler.java
@@ -12,6 +12,7 @@ import net.nurigo.sdk.message.model.StorageType;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
 import net.nurigo.sdk.message.response.SingleMessageSentResponse;
 import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -48,6 +49,7 @@ public class SendQrEventHandler {
     private final TraineeRepository traineeRepository;
     private final SmsProperties smsProperties;
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public SingleMessageSentResponse sendQrHandler(SendQrEvent sendQrEvent) {
         SingleMessageSentResponse response = null;


### PR DESCRIPTION
## 💡 배경 및 개요

sms 문자를 발송하는 과정에서 ApplicationEvent를 사용하여 동기적으로 처리하는데 많은 사람들이 동시에 박람회 신청을 하게 된다면 동기적으로 처리하는 것보다 비동기로 처리하는 것이 효율적이라고 생각이 들어 비동기로 변경하였습니다

Resolves: #233 

## 📃 작업내용

* sendQrHandler Async 처리

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타