### PR TITLE
🔀 :: form 및 survey Path 변경

### DIFF
--- a/src/main/java/team/startup/expo/domain/form/presentation/FormController.java
+++ b/src/main/java/team/startup/expo/domain/form/presentation/FormController.java
@@ -29,9 +29,9 @@ public class FormController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @PatchMapping("/{form_id}")
-    public ResponseEntity<Void> updateForm(@PathVariable("form_id") Long formId, @RequestBody @Valid FormRequestDto dto) {
-        updateFormService.execute(formId, dto);
+    @PatchMapping("/{expo_id}")
+    public ResponseEntity<Void> updateForm(@PathVariable("expo_id") String expoId, @RequestBody @Valid FormRequestDto dto) {
+        updateFormService.execute(expoId, dto);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/src/main/java/team/startup/expo/domain/form/presentation/FormController.java
+++ b/src/main/java/team/startup/expo/domain/form/presentation/FormController.java
@@ -35,9 +35,9 @@ public class FormController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @DeleteMapping("/{form_id}")
-    public ResponseEntity<Void> deleteForm(@PathVariable("form_id") Long formId) {
-        deleteFormService.execute(formId);
+    @DeleteMapping("/{expo_id}/{participationType}")
+    public ResponseEntity<Void> deleteForm(@PathVariable("expo_id") String expoId, @PathVariable ParticipationType participationType) {
+        deleteFormService.execute(expoId, participationType);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/src/main/java/team/startup/expo/domain/form/service/DeleteFormService.java
+++ b/src/main/java/team/startup/expo/domain/form/service/DeleteFormService.java
@@ -1,5 +1,7 @@
 package team.startup.expo.domain.form.service;
 
+import team.startup.expo.domain.form.entity.ParticipationType;
+
 public interface DeleteFormService {
-    void execute(Long formId);
+    void execute(String expoId, ParticipationType participationType);
 }

--- a/src/main/java/team/startup/expo/domain/form/service/UpdateFormService.java
+++ b/src/main/java/team/startup/expo/domain/form/service/UpdateFormService.java
@@ -3,5 +3,5 @@ package team.startup.expo.domain.form.service;
 import team.startup.expo.domain.form.presentation.dto.request.FormRequestDto;
 
 public interface UpdateFormService {
-    void execute(Long formId, FormRequestDto dto);
+    void execute(String expoId, FormRequestDto dto);
 }

--- a/src/main/java/team/startup/expo/domain/form/service/impl/DeleteFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/DeleteFormServiceImpl.java
@@ -1,7 +1,11 @@
 package team.startup.expo.domain.form.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.expo.exception.NotFoundExpoException;
+import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.form.entity.Form;
+import team.startup.expo.domain.form.entity.ParticipationType;
 import team.startup.expo.domain.form.exception.NotFoundFormException;
 import team.startup.expo.domain.form.repository.DynamicFormRepository;
 import team.startup.expo.domain.form.repository.FormRepository;
@@ -12,11 +16,15 @@ import team.startup.expo.global.annotation.TransactionService;
 @RequiredArgsConstructor
 public class DeleteFormServiceImpl implements DeleteFormService {
 
+    private final ExpoRepository expoRepository;
     private final FormRepository formRepository;
     private final DynamicFormRepository dynamicFormRepository;
 
-    public void execute(Long formId) {
-        Form form = formRepository.findById(formId)
+    public void execute(String expoId, ParticipationType participationType) {
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(NotFoundExpoException::new);
+
+        Form form = formRepository.findByExpoAndParticipationType(expo, participationType)
                 .orElseThrow(NotFoundFormException::new);
 
         dynamicFormRepository.deleteByForm(form);

--- a/src/main/java/team/startup/expo/domain/form/service/impl/UpdateFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/UpdateFormServiceImpl.java
@@ -1,6 +1,8 @@
 package team.startup.expo.domain.form.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.form.entity.DynamicForm;
 import team.startup.expo.domain.form.entity.Form;
 import team.startup.expo.domain.form.exception.NotFoundFormException;
@@ -10,17 +12,19 @@ import team.startup.expo.domain.form.repository.FormRepository;
 import team.startup.expo.domain.form.service.UpdateFormService;
 import team.startup.expo.global.annotation.TransactionService;
 
-import java.util.List;
-
 @TransactionService
 @RequiredArgsConstructor
 public class UpdateFormServiceImpl implements UpdateFormService {
 
+    private final ExpoRepository expoRepository;
     private final FormRepository formRepository;
     private final DynamicFormRepository dynamicFormRepository;
 
-    public void execute(Long formId, FormRequestDto dto) {
-        Form form = formRepository.findById(formId)
+    public void execute(String expoId, FormRequestDto dto) {
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(NotFoundFormException::new);
+
+        Form form = formRepository.findByExpoAndParticipationType(expo, dto.getParticipantType())
                 .orElseThrow(NotFoundFormException::new);
 
         dynamicFormRepository.deleteByForm(form);

--- a/src/main/java/team/startup/expo/domain/survey/management/presentation/SurveyController.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/presentation/SurveyController.java
@@ -41,9 +41,9 @@ public class SurveyController {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/{expo_id}")
-    public ResponseEntity<Void> deleteSurvey(@PathVariable("expo_id") String expoId) {
-        deleteSurveyService.execute(expoId);
+    @DeleteMapping("/{expo_id}/{participationType}")
+    public ResponseEntity<Void> deleteSurvey(@PathVariable("expo_id") String expoId, @PathVariable ParticipationType participationType) {
+        deleteSurveyService.execute(expoId, participationType);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/repository/DynamicSurveyRepository.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/repository/DynamicSurveyRepository.java
@@ -2,7 +2,7 @@ package team.startup.expo.domain.survey.management.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
+
 import team.startup.expo.domain.survey.management.entity.DynamicSurvey;
 import team.startup.expo.domain.survey.management.entity.Survey;
 
@@ -11,7 +11,5 @@ import java.util.List;
 public interface DynamicSurveyRepository extends JpaRepository<DynamicSurvey, Long> {
     List<DynamicSurvey> findBySurvey(Survey survey);
     @Modifying(clearAutomatically = true)
-    @Query("DELETE DynamicSurvey ds WHERE ds.survey IN :surveys")
-    void deleteBySurveys(List<Survey> surveys);
     void deleteBySurvey(Survey survey);
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/service/DeleteSurveyService.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/DeleteSurveyService.java
@@ -1,5 +1,7 @@
 package team.startup.expo.domain.survey.management.service;
 
+import team.startup.expo.domain.form.entity.ParticipationType;
+
 public interface DeleteSurveyService {
-    void execute(String expoId);
+    void execute(String expoId, ParticipationType participationType);
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/service/impl/DeleteSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/impl/DeleteSurveyServiceImpl.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.form.entity.ParticipationType;
 import team.startup.expo.domain.survey.management.entity.Survey;
+import team.startup.expo.domain.survey.management.exception.NotFoundSurveyException;
 import team.startup.expo.domain.survey.management.repository.DynamicSurveyRepository;
 import team.startup.expo.domain.survey.management.repository.SurveyRepository;
 import team.startup.expo.domain.survey.management.service.DeleteSurveyService;
@@ -20,13 +22,14 @@ public class DeleteSurveyServiceImpl implements DeleteSurveyService {
     private final DynamicSurveyRepository dynamicSurveyRepository;
     private final ExpoRepository expoRepository;
 
-    public void execute(String expoId) {
+    public void execute(String expoId, ParticipationType participationType) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
-        List<Survey> surveyList = surveyRepository.findByExpo(expo);
+        Survey survey = surveyRepository.findByExpoAndParticipationType(expo, participationType)
+                .orElseThrow(NotFoundSurveyException::new);
 
-        dynamicSurveyRepository.deleteBySurveys(surveyList);
-        surveyRepository.deleteAll(surveyList);
+        dynamicSurveyRepository.deleteBySurvey(survey);
+        surveyRepository.delete(survey);
     }
 }

--- a/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
@@ -135,14 +135,14 @@ public class SecurityConfig {
                                 // form
                                 .requestMatchers(HttpMethod.POST, "/form/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
                                 .requestMatchers(HttpMethod.PATCH, "/form/{form_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
-                                .requestMatchers(HttpMethod.DELETE, "/form/{form_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
+                                .requestMatchers(HttpMethod.DELETE, "/form/{form_id}/{participationType}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
                                 .requestMatchers(HttpMethod.GET, "/form/{expo_id}").permitAll()
 
                                 // survey
                                 .requestMatchers(HttpMethod.POST, "/survey/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
                                 .requestMatchers(HttpMethod.GET, "/survey/{expo_id}").permitAll()
                                 .requestMatchers(HttpMethod.PATCH, "/survey/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
-                                .requestMatchers(HttpMethod.DELETE, "/survey/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
+                                .requestMatchers(HttpMethod.DELETE, "/survey/{expo_id}/{participationType}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
 
                                 // surveyAnswer
                                 .requestMatchers(HttpMethod.POST, "/survey/answer/standard/{expo_id}").permitAll()


### PR DESCRIPTION
## 💡 배경 및 개요

form과 survey의 Update와 Delete api에서 participationType을 추가로 받아 특정 엔티티만 삭제또는 수정할 수 있도록 변경하였습니다

Resolves: #235 

## 📃 작업내용

* form update Path 변경 : formId -> expoId
* form Delete Path 추가 : `/{expo_id}` -> `/{expo_id}/{participationType}`
* survey Delete Path 추가 : `/{expo_id}` -> `/{expo_id}/{participationType}`

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타