### PR TITLE
🔀 :: 일반 관람객 사전/현장 신청 폼 불러오기 API 캐싱

### DIFF
--- a/src/main/java/team/startup/expo/ExpoApplication.java
+++ b/src/main/java/team/startup/expo/ExpoApplication.java
@@ -4,6 +4,7 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 import java.util.TimeZone;
@@ -11,6 +12,7 @@ import java.util.TimeZone;
 @EnableAsync
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableCaching
 public class ExpoApplication {
 
 	@PostConstruct

--- a/src/main/java/team/startup/expo/domain/form/presentation/dto/response/GetFormResponseDto.java
+++ b/src/main/java/team/startup/expo/domain/form/presentation/dto/response/GetFormResponseDto.java
@@ -1,13 +1,17 @@
 package team.startup.expo.domain.form.presentation.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import team.startup.expo.domain.form.entity.FormType;
 import team.startup.expo.domain.form.entity.ParticipationType;
 
 import java.util.List;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 public class GetFormResponseDto {
     private String informationImage;
@@ -16,6 +20,8 @@ public class GetFormResponseDto {
 
     @Getter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class DynamicFormRequestDto {
         private String title;
         private FormType formType;

--- a/src/main/java/team/startup/expo/domain/form/service/impl/DeleteFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/DeleteFormServiceImpl.java
@@ -1,6 +1,8 @@
 package team.startup.expo.domain.form.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
@@ -14,12 +16,14 @@ import team.startup.expo.global.annotation.TransactionService;
 
 @TransactionService
 @RequiredArgsConstructor
+@CacheConfig(cacheNames = "Form")
 public class DeleteFormServiceImpl implements DeleteFormService {
 
     private final ExpoRepository expoRepository;
     private final FormRepository formRepository;
     private final DynamicFormRepository dynamicFormRepository;
 
+    @CacheEvict(key = "#expoId + '_' + #participationType")
     public void execute(String expoId, ParticipationType participationType) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);

--- a/src/main/java/team/startup/expo/domain/form/service/impl/GetFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/GetFormServiceImpl.java
@@ -1,6 +1,8 @@
 package team.startup.expo.domain.form.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
@@ -18,12 +20,14 @@ import java.util.List;
 
 @ReadOnlyTransactionService
 @RequiredArgsConstructor
+@CacheConfig(cacheNames = "Form")
 public class GetFormServiceImpl implements GetFormService {
 
     private final FormRepository formRepository;
     private final ExpoRepository expoRepository;
     private final DynamicFormRepository dynamicFormRepository;
 
+    @Cacheable(key = "#expoId + '_' + #participationType")
     public GetFormResponseDto execute(String expoId, ParticipationType participationType) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);

--- a/src/main/java/team/startup/expo/domain/form/service/impl/UpdateFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/UpdateFormServiceImpl.java
@@ -1,6 +1,8 @@
 package team.startup.expo.domain.form.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.form.entity.DynamicForm;
@@ -14,12 +16,14 @@ import team.startup.expo.global.annotation.TransactionService;
 
 @TransactionService
 @RequiredArgsConstructor
+@CacheConfig(cacheNames = "Form")
 public class UpdateFormServiceImpl implements UpdateFormService {
 
     private final ExpoRepository expoRepository;
     private final FormRepository formRepository;
     private final DynamicFormRepository dynamicFormRepository;
 
+    @CacheEvict(key = "#expoId + '_' + #dto.participantType")
     public void execute(String expoId, FormRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundFormException::new);

--- a/src/main/java/team/startup/expo/global/redis/RedisConfig.java
+++ b/src/main/java/team/startup/expo/global/redis/RedisConfig.java
@@ -49,14 +49,10 @@ public class RedisConfig {
                 .entryTtl(Duration.ofMinutes(120L))
                 .disableCachingNullValues();
 
-        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
-        cacheConfigurations.put("Form", cacheConfig.prefixCacheNameWith("Form::"));
-
         return RedisCacheManager
                 .RedisCacheManagerBuilder
                 .fromConnectionFactory(factory)
                 .cacheDefaults(cacheConfig)
-                .withInitialCacheConfigurations(cacheConfigurations)
                 .build();
     }
 }

--- a/src/main/java/team/startup/expo/global/redis/RedisConfig.java
+++ b/src/main/java/team/startup/expo/global/redis/RedisConfig.java
@@ -1,11 +1,21 @@
 package team.startup.expo.global.redis;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 public class RedisConfig {
@@ -29,5 +39,24 @@ public class RedisConfig {
         RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         return redisTemplate;
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory factory) {
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofMinutes(120L))
+                .disableCachingNullValues();
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+        cacheConfigurations.put("Form", cacheConfig.prefixCacheNameWith("Form::"));
+
+        return RedisCacheManager
+                .RedisCacheManagerBuilder
+                .fromConnectionFactory(factory)
+                .cacheDefaults(cacheConfig)
+                .withInitialCacheConfigurations(cacheConfigurations)
+                .build();
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요

일반 관람객 사전/현장 신청에 필요한 폼을 불러오는 응답을 Redis를 이용해 캐싱하여 성능개선하였습니다.

Resolves: #244 

## 📃 작업내용

* cacheManager 설정
* API 캐싱 및 동기화 설정

## 🙋‍♂️ 리뷰노트

![image](https://github.com/user-attachments/assets/4fd59729-a230-4001-86dc-50bcbff4ff41)
![image](https://github.com/user-attachments/assets/107d6619-10f2-4e13-ab0a-d29030a317c8)

**테스트 시 레이턴시 약 95%감소

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타