### PR TITLE
🔀 :: 설문조사 관련 RedisCache 적용

### DIFF
--- a/src/main/java/team/startup/expo/domain/form/service/impl/DeleteFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/DeleteFormServiceImpl.java
@@ -23,7 +23,7 @@ public class DeleteFormServiceImpl implements DeleteFormService {
     private final FormRepository formRepository;
     private final DynamicFormRepository dynamicFormRepository;
 
-    @CacheEvict(key = "#expoId + '_' + #participationType")
+    @CacheEvict(key = "#expoId + '_' + #participationType", cacheNames = "cacheManager")
     public void execute(String expoId, ParticipationType participationType) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);

--- a/src/main/java/team/startup/expo/domain/form/service/impl/GetFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/GetFormServiceImpl.java
@@ -27,7 +27,7 @@ public class GetFormServiceImpl implements GetFormService {
     private final ExpoRepository expoRepository;
     private final DynamicFormRepository dynamicFormRepository;
 
-    @Cacheable(key = "#expoId + '_' + #participationType")
+    @Cacheable(key = "#expoId + '_' + #participationType", cacheManager = "cacheManager")
     public GetFormResponseDto execute(String expoId, ParticipationType participationType) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);

--- a/src/main/java/team/startup/expo/domain/form/service/impl/UpdateFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/UpdateFormServiceImpl.java
@@ -23,7 +23,7 @@ public class UpdateFormServiceImpl implements UpdateFormService {
     private final FormRepository formRepository;
     private final DynamicFormRepository dynamicFormRepository;
 
-    @CacheEvict(key = "#expoId + '_' + #dto.participantType")
+    @CacheEvict(key = "#expoId + '_' + #dto.participantType", cacheManager = "cacheManager")
     public void execute(String expoId, FormRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundFormException::new);

--- a/src/main/java/team/startup/expo/domain/survey/management/presentation/dto/response/SurveyResponseDto.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/presentation/dto/response/SurveyResponseDto.java
@@ -1,13 +1,17 @@
 package team.startup.expo.domain.survey.management.presentation.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import team.startup.expo.domain.form.entity.FormType;
 import team.startup.expo.domain.form.entity.ParticipationType;
 
 import java.util.List;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 @Builder
 public class SurveyResponseDto {
     private ParticipationType participationType;
@@ -15,6 +19,8 @@ public class SurveyResponseDto {
 
     @Getter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class DynamicSurveyResponseDto {
         private String title;
         private String jsonData;

--- a/src/main/java/team/startup/expo/domain/survey/management/service/impl/DeleteSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/impl/DeleteSurveyServiceImpl.java
@@ -1,6 +1,8 @@
 package team.startup.expo.domain.survey.management.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
@@ -12,16 +14,16 @@ import team.startup.expo.domain.survey.management.repository.SurveyRepository;
 import team.startup.expo.domain.survey.management.service.DeleteSurveyService;
 import team.startup.expo.global.annotation.TransactionService;
 
-import java.util.List;
-
 @TransactionService
 @RequiredArgsConstructor
+@CacheConfig(cacheNames = "Survey")
 public class DeleteSurveyServiceImpl implements DeleteSurveyService {
 
     private final SurveyRepository surveyRepository;
     private final DynamicSurveyRepository dynamicSurveyRepository;
     private final ExpoRepository expoRepository;
 
+    @CacheEvict(key = "#expoId + '_' + #participationType", cacheManager = "cacheManager")
     public void execute(String expoId, ParticipationType participationType) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);

--- a/src/main/java/team/startup/expo/domain/survey/management/service/impl/GetSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/impl/GetSurveyServiceImpl.java
@@ -1,6 +1,8 @@
 package team.startup.expo.domain.survey.management.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
@@ -18,12 +20,14 @@ import java.util.List;
 
 @ReadOnlyTransactionService
 @RequiredArgsConstructor
+@CacheConfig(cacheNames = "Survey")
 public class GetSurveyServiceImpl implements GetSurveyService {
 
     private final SurveyRepository surveyRepository;
     private final DynamicSurveyRepository dynamicSurveyRepository;
     private final ExpoRepository expoRepository;
 
+    @Cacheable(key = "#expoId + '_' + #participationType", cacheManager = "cacheManager")
     public SurveyResponseDto execute(String expoId, ParticipationType participationType) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);

--- a/src/main/java/team/startup/expo/domain/survey/management/service/impl/UpdateSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/impl/UpdateSurveyServiceImpl.java
@@ -1,6 +1,8 @@
 package team.startup.expo.domain.survey.management.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
@@ -15,12 +17,14 @@ import team.startup.expo.global.annotation.TransactionService;
 
 @TransactionService
 @RequiredArgsConstructor
+@CacheConfig(cacheNames = "Survey")
 public class UpdateSurveyServiceImpl implements UpdateSurveyService {
 
     private final SurveyRepository surveyRepository;
     private final DynamicSurveyRepository dynamicSurveyRepository;
     private final ExpoRepository expoRepository;
 
+    @CacheEvict(key = "#expoId + '_' + #dto.participationType", cacheManager = "cacheManager")
     public void execute(String expoId, SurveyRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);

--- a/src/main/java/team/startup/expo/global/redis/RedisConfig.java
+++ b/src/main/java/team/startup/expo/global/redis/RedisConfig.java
@@ -42,11 +42,11 @@ public class RedisConfig {
     }
 
     @Bean
-    public CacheManager cacheManager(RedisConnectionFactory factory) {
+        public CacheManager cacheManager(RedisConnectionFactory factory) {
         RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
-                .entryTtl(Duration.ofMinutes(120L))
+                .entryTtl(Duration.ofHours(2))
                 .disableCachingNullValues();
 
         return RedisCacheManager


### PR DESCRIPTION
## 💡 배경 및 개요

설문조사 관련 API들을 Redis를 사용하여 Cache를 적용하였습니다.

Resolves: #245 

## 📃 작업내용

* 설문조사 삭제/ 수정 CacheEvict 적용
* 설문조사 불러오기 CacheEvict 적용

## 🙋‍♂️ 리뷰노트

![image](https://github.com/user-attachments/assets/aca29735-1e87-4fe8-8514-46c4a575af5f)
![image](https://github.com/user-attachments/assets/27fc7d7b-7ad8-4f1a-b3e2-f9297531fb23)
레이턴시 약 93% 감소하였습니다

Look Aside + Write Around 조합을 사용하여 구현하였습니다

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타