### PR TITLE
🔀 :: 박람회 참가자 통계 그래프 수치 API

### DIFF
--- a/src/main/java/team/startup/expo/domain/stat/presentation/StatController.java
+++ b/src/main/java/team/startup/expo/domain/stat/presentation/StatController.java
@@ -1,0 +1,26 @@
+package team.startup.expo.domain.stat.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team.startup.expo.domain.stat.presentation.dto.response.StandardParticipantStatsResponse;
+import team.startup.expo.domain.stat.service.GetStandardStatsService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/stat")
+public class StatController {
+
+    private final GetStandardStatsService getStandardStatsService;
+
+    @GetMapping("/{expo_id}")
+    public ResponseEntity<StandardParticipantStatsResponse> getStandardStats(
+        @PathVariable("expo_id") String expoId
+    ) {
+        StandardParticipantStatsResponse response = getStandardStatsService.execute(expoId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/team/startup/expo/domain/stat/presentation/dto/response/StandardParticipantStatsResponse.java
+++ b/src/main/java/team/startup/expo/domain/stat/presentation/dto/response/StandardParticipantStatsResponse.java
@@ -1,0 +1,49 @@
+package team.startup.expo.domain.stat.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StandardParticipantStatsResponse {
+    private ElementaryDto elementary;
+    private MiddleDto middle;
+    private HighDto high;
+    private KindergartenDto kindergarten;
+    private OtherDto other;
+
+    @Getter
+    @Builder
+    public static class ElementaryDto {
+        private Integer number;
+        private Integer percent;
+    }
+
+    @Getter
+    @Builder
+    public static class MiddleDto {
+        private Integer number;
+        private Integer percent;
+    }
+
+    @Getter
+    @Builder
+    public static class HighDto {
+        private Integer number;
+        private Integer percent;
+    }
+
+    @Getter
+    @Builder
+    public static class KindergartenDto {
+        private Integer number;
+        private Integer percent;
+    }
+
+    @Getter
+    @Builder
+    public static class OtherDto {
+        private Integer number;
+        private Integer percent;
+    }
+}

--- a/src/main/java/team/startup/expo/domain/stat/presentation/dto/response/StandardParticipantStatsResponse.java
+++ b/src/main/java/team/startup/expo/domain/stat/presentation/dto/response/StandardParticipantStatsResponse.java
@@ -16,34 +16,34 @@ public class StandardParticipantStatsResponse {
     @Builder
     public static class ElementaryDto {
         private Integer number;
-        private Integer percent;
+        private Float percent;
     }
 
     @Getter
     @Builder
     public static class MiddleDto {
         private Integer number;
-        private Integer percent;
+        private Float percent;
     }
 
     @Getter
     @Builder
     public static class HighDto {
         private Integer number;
-        private Integer percent;
+        private Float percent;
     }
 
     @Getter
     @Builder
     public static class KindergartenDto {
         private Integer number;
-        private Integer percent;
+        private Float percent;
     }
 
     @Getter
     @Builder
     public static class OtherDto {
         private Integer number;
-        private Integer percent;
+        private Float percent;
     }
 }

--- a/src/main/java/team/startup/expo/domain/stat/service/GetStandardStatsService.java
+++ b/src/main/java/team/startup/expo/domain/stat/service/GetStandardStatsService.java
@@ -1,0 +1,7 @@
+package team.startup.expo.domain.stat.service;
+
+import team.startup.expo.domain.stat.presentation.dto.response.StandardParticipantStatsResponse;
+
+public interface GetStandardStatsService {
+    StandardParticipantStatsResponse execute(String expoId);
+}

--- a/src/main/java/team/startup/expo/domain/stat/service/impl/GetStandardStatsServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/stat/service/impl/GetStandardStatsServiceImpl.java
@@ -41,7 +41,7 @@ public class GetStandardStatsServiceImpl implements GetStandardStatsService {
                 .count();
 
         int allCount = participants.size();
-        int elementaryPercent = elementaryCount * 100 / allCount;
+        float elementaryPercent = (float) Math.round((elementaryCount * 100.0 / allCount));
 
         return StandardParticipantStatsResponse.ElementaryDto.builder()
                 .number(elementaryCount)
@@ -55,7 +55,7 @@ public class GetStandardStatsServiceImpl implements GetStandardStatsService {
                 .count();
 
         int allCount = participants.size();
-        int middlePercent = middleCount * 100 / allCount;
+        float middlePercent = (float) Math.round(middleCount * 100.0 / allCount);
 
         return StandardParticipantStatsResponse.MiddleDto.builder()
                 .number(middleCount)
@@ -69,7 +69,7 @@ public class GetStandardStatsServiceImpl implements GetStandardStatsService {
                 .count();
 
         int allCount = participants.size();
-        int highPercent = highCount * 100 / allCount;
+        float highPercent = (float) Math.round(highCount * 100.0 / allCount);
 
         return StandardParticipantStatsResponse.HighDto.builder()
                 .number(highCount)
@@ -83,7 +83,7 @@ public class GetStandardStatsServiceImpl implements GetStandardStatsService {
                 .count();
 
         int allCount = participants.size();
-        int kindergartenPercent = kindergartenCount * 100 / allCount;
+        float kindergartenPercent = (float) Math.round(kindergartenCount * 100.0 / allCount);
 
         return StandardParticipantStatsResponse.KindergartenDto.builder()
                 .number(kindergartenCount)
@@ -97,7 +97,7 @@ public class GetStandardStatsServiceImpl implements GetStandardStatsService {
                 .count();
 
         int allCount = participants.size();
-        int otherPercent = otherCount * 100 / allCount;
+        float otherPercent = (float) Math.round(otherCount * 100.0 / allCount);
 
         return StandardParticipantStatsResponse.OtherDto.builder()
                 .number(otherCount)

--- a/src/main/java/team/startup/expo/domain/stat/service/impl/GetStandardStatsServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/stat/service/impl/GetStandardStatsServiceImpl.java
@@ -1,0 +1,107 @@
+package team.startup.expo.domain.stat.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.expo.exception.NotFoundExpoException;
+import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.participant.entity.SchoolLevel;
+import team.startup.expo.domain.participant.entity.StandardParticipant;
+import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
+import team.startup.expo.domain.stat.presentation.dto.response.StandardParticipantStatsResponse;
+import team.startup.expo.domain.stat.service.GetStandardStatsService;
+import team.startup.expo.global.annotation.ReadOnlyTransactionService;
+
+import java.util.List;
+
+@ReadOnlyTransactionService
+@RequiredArgsConstructor
+public class GetStandardStatsServiceImpl implements GetStandardStatsService {
+
+    private final StandardParticipantRepository standardParticipantRepository;
+    private final ExpoRepository expoRepository;
+
+    public StandardParticipantStatsResponse execute(String expoId) {
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(NotFoundExpoException::new);
+
+        List<StandardParticipant> expoParticipant = standardParticipantRepository.findByExpo(expo);
+
+        return StandardParticipantStatsResponse.builder()
+                .elementary(mapElementaryDto(expoParticipant))
+                .middle(mapMiddleDto(expoParticipant))
+                .high(mapHighDto(expoParticipant))
+                .kindergarten(mapKindergartenDto(expoParticipant))
+                .other(mapOtherDto(expoParticipant))
+                .build();
+    }
+
+    private StandardParticipantStatsResponse.ElementaryDto mapElementaryDto(List<StandardParticipant> participants) {
+        int elementaryCount = (int) participants.stream()
+                .filter(sp -> sp.getSchoolLevel().equals(SchoolLevel.ELEMENTARY))
+                .count();
+
+        int allCount = participants.size();
+        int elementaryPercent = elementaryCount * 100 / allCount;
+
+        return StandardParticipantStatsResponse.ElementaryDto.builder()
+                .number(elementaryCount)
+                .percent(elementaryPercent)
+                .build();
+    }
+
+    private StandardParticipantStatsResponse.MiddleDto mapMiddleDto(List<StandardParticipant> participants) {
+        int middleCount = (int) participants.stream()
+                .filter(sp -> sp.getSchoolLevel().equals(SchoolLevel.MIDDLE))
+                .count();
+
+        int allCount = participants.size();
+        int middlePercent = middleCount * 100 / allCount;
+
+        return StandardParticipantStatsResponse.MiddleDto.builder()
+                .number(middleCount)
+                .percent(middlePercent)
+                .build();
+    }
+
+    private StandardParticipantStatsResponse.HighDto mapHighDto(List<StandardParticipant> participants) {
+        int highCount = (int) participants.stream()
+                .filter(sp -> sp.getSchoolLevel().equals(SchoolLevel.HIGH))
+                .count();
+
+        int allCount = participants.size();
+        int highPercent = highCount * 100 / allCount;
+
+        return StandardParticipantStatsResponse.HighDto.builder()
+                .number(highCount)
+                .percent(highPercent)
+                .build();
+    }
+
+    private StandardParticipantStatsResponse.KindergartenDto mapKindergartenDto(List<StandardParticipant> participants) {
+        int kindergartenCount = (int) participants.stream()
+                .filter(sp -> sp.getSchoolLevel().equals(SchoolLevel.KINDERGARTEN))
+                .count();
+
+        int allCount = participants.size();
+        int kindergartenPercent = kindergartenCount * 100 / allCount;
+
+        return StandardParticipantStatsResponse.KindergartenDto.builder()
+                .number(kindergartenCount)
+                .percent(kindergartenPercent)
+                .build();
+    }
+
+    private StandardParticipantStatsResponse.OtherDto mapOtherDto(List<StandardParticipant> participants) {
+        int otherCount = (int) participants.stream()
+                .filter(sp -> sp.getSchoolLevel().equals(SchoolLevel.OTHER))
+                .count();
+
+        int allCount = participants.size();
+        int otherPercent = otherCount * 100 / allCount;
+
+        return StandardParticipantStatsResponse.OtherDto.builder()
+                .number(otherCount)
+                .percent(otherPercent)
+                .build();
+    }
+}

--- a/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/expo/global/security/config/SecurityConfig.java
@@ -87,7 +87,7 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.POST, "/auth").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/auth/signin").permitAll()
                                 .requestMatchers(HttpMethod.PATCH, "/auth").permitAll()
-                                .requestMatchers(HttpMethod.DELETE, "/auth").authenticated()
+                                .requestMatchers(HttpMethod.DELETE, "/auth").hasAnyAuthority(Authority.ROLE_ADMIN.name())
 
                                 // trainee
                                 .requestMatchers(HttpMethod.GET, "/trainee/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
@@ -118,8 +118,8 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.POST, "/expo").hasAnyAuthority(Authority.ROLE_ADMIN.name())
                                 .requestMatchers(HttpMethod.PATCH, "/expo/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
                                 .requestMatchers(HttpMethod.DELETE, "/expo/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
-                                .requestMatchers(HttpMethod.GET, "/expo/{expo_id}").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/expo").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/expo/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
+                                .requestMatchers(HttpMethod.GET, "/expo").hasAnyAuthority(Authority.ROLE_ADMIN.name())
                                 .requestMatchers(HttpMethod.GET, "/expo/valid/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
 
                                 // attendance
@@ -149,6 +149,9 @@ public class SecurityConfig {
                                 // surveyAnswer
                                 .requestMatchers(HttpMethod.POST, "/survey/answer/standard/{expo_id}").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/survey/answer/trainee/{expo_id}").permitAll()
+
+                                // stat
+                                .requestMatchers(HttpMethod.GET, "/stat/{expo_id}").hasAnyAuthority(Authority.ROLE_ADMIN.name())
 
                                 //image
                                 .requestMatchers(HttpMethod.POST, "/image").authenticated()


### PR DESCRIPTION
## 💡 배경 및 개요

박람회 참가자 통계 그래프에 대한 정보를 반환하는 API를 개발하였습니다

Resolves: #252 

## 📃 작업내용

* getStandardStats API 추가

## 🙋‍♂️ 리뷰노트

percent의 합계가 100으로 나오지 않는 문제를 반올림처리하여 100으로 나오도록 하였습니다

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타