### PR TITLE
🔀 :: 폼 개인정보동의 이미지에서 텍스트로 변경

### DIFF
--- a/src/main/java/team/startup/expo/domain/form/entity/Form.java
+++ b/src/main/java/team/startup/expo/domain/form/entity/Form.java
@@ -22,8 +22,8 @@ public class Form {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(columnDefinition = "TEXT")
-    private String informationImage;
+    @Column(nullable = false, length = 500)
+    private String informationText;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
@@ -35,7 +35,7 @@ public class Form {
     private Expo expo;
 
     public void updateForm(FormRequestDto dto) {
-        this.informationImage = dto.getInformationImage();
+        this.informationText = dto.getInformationText();
         this.participationType = dto.getParticipantType();
     }
 }

--- a/src/main/java/team/startup/expo/domain/form/presentation/dto/request/FormRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/form/presentation/dto/request/FormRequestDto.java
@@ -12,7 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 public class FormRequestDto {
     @NotNull
-    private String informationImage;
+    private String informationText;
 
     @NotNull
     private ParticipationType participantType;

--- a/src/main/java/team/startup/expo/domain/form/presentation/dto/response/GetFormResponseDto.java
+++ b/src/main/java/team/startup/expo/domain/form/presentation/dto/response/GetFormResponseDto.java
@@ -14,7 +14,7 @@ import java.util.List;
 @NoArgsConstructor
 @Builder
 public class GetFormResponseDto {
-    private String informationImage;
+    private String informationText;
     private ParticipationType participantType;
     private List<GetFormResponseDto.DynamicFormRequestDto> dynamicForm;
 

--- a/src/main/java/team/startup/expo/domain/form/service/impl/CreateFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/CreateFormServiceImpl.java
@@ -35,7 +35,7 @@ public class CreateFormServiceImpl implements CreateFormService {
 
     private Form saveForm(FormRequestDto formRequestDto, Expo expo) {
         Form form = Form.builder()
-                .informationImage(formRequestDto.getInformationImage())
+                .informationText(formRequestDto.getInformationText())
                 .participationType(formRequestDto.getParticipantType())
                 .expo(expo)
                 .build();

--- a/src/main/java/team/startup/expo/domain/form/service/impl/GetFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/GetFormServiceImpl.java
@@ -48,7 +48,7 @@ public class GetFormServiceImpl implements GetFormService {
                 ).toList();
 
         return GetFormResponseDto.builder()
-                .informationImage(form.getInformationImage())
+                .informationText(form.getInformationText())
                 .participantType(form.getParticipationType())
                 .dynamicForm(dynamicFormRequestDtoList)
                 .build();

--- a/src/main/java/team/startup/expo/domain/survey/management/entity/Survey.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/entity/Survey.java
@@ -26,8 +26,16 @@ public class Survey {
     @Column(nullable = false)
     private ParticipationType participationType;
 
+    @Column(nullable = false, length = 500)
+    private String informationText;
+
     @ManyToOne
     @JoinColumn(name = "expo_id")
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Expo expo;
+
+    public void update(String informationText) {
+        this.informationText = informationText;
+    }
 }
+

--- a/src/main/java/team/startup/expo/domain/survey/management/presentation/dto/request/SurveyRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/presentation/dto/request/SurveyRequestDto.java
@@ -15,6 +15,9 @@ public class SurveyRequestDto {
     private ParticipationType participationType;
 
     @NotNull
+    private String informationText;
+
+    @NotNull
     private List<DynamicSurveyRequestDto> dynamicSurveyRequestDto;
 
     @Getter

--- a/src/main/java/team/startup/expo/domain/survey/management/service/impl/CreateSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/impl/CreateSurveyServiceImpl.java
@@ -36,6 +36,7 @@ public class CreateSurveyServiceImpl implements CreateSurveyService {
     private Survey saveSurvey(SurveyRequestDto dto, Expo expo) {
         Survey survey = Survey.builder()
                 .participationType(dto.getParticipationType())
+                .informationText(dto.getInformationText())
                 .expo(expo)
                 .build();
 

--- a/src/main/java/team/startup/expo/domain/survey/management/service/impl/UpdateSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/impl/UpdateSurveyServiceImpl.java
@@ -32,6 +32,7 @@ public class UpdateSurveyServiceImpl implements UpdateSurveyService {
         Survey survey = surveyRepository.findByExpoAndParticipationType(expo, dto.getParticipationType())
                 .orElseThrow(NotFoundSurveyException::new);
 
+        survey.update(dto.getInformationText());
         dynamicSurveyRepository.deleteBySurvey(survey);
         dto.getDynamicSurveyRequestDto().forEach(dynamicSurveyRequestDto -> saveDynamicSurvey(dynamicSurveyRequestDto, survey));
     }


### PR DESCRIPTION
## 💡 배경 및 개요

개인정보동의관련 문장을 이미지가 아닌 텍스트로 직접 입력하여 하는 방식으로 바뀌어 수정하였습니다

Resolves: #255 

## 📃 작업내용

* informationImage -> informationText 폼 엔티티 변경
* informationText 설문조사 추가

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타