### PR TITLE
🔀 :: 박람회 사전/현장 신청 row lock 적용

### DIFF
--- a/src/main/java/team/startup/expo/domain/application/presentation/ApplicationController.java
+++ b/src/main/java/team/startup/expo/domain/application/presentation/ApplicationController.java
@@ -23,31 +23,46 @@ public class ApplicationController {
     private final FieldApplicationTemporaryQrService fieldApplicationTemporaryQrService;
 
     @PostMapping("/{expo_id}")
-    public ResponseEntity<Void> preApplicationForTrainee(@PathVariable("expo_id") String expoId, @RequestBody @Valid ApplicationForTraineeRequestDto dto) {
+    public ResponseEntity<Void> preApplicationForTrainee(
+        @PathVariable("expo_id") String expoId,
+        @RequestBody @Valid ApplicationForTraineeRequestDto dto
+    ) {
         preApplicationForTraineeService.execute(expoId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PostMapping("/pre-standard/{expo_id}")
-    public ResponseEntity<Void> preApplicationForParticipant(@PathVariable("expo_id") String expoId, @RequestBody @Valid ApplicationForParticipantRequestDto dto) {
+    public ResponseEntity<Void> preApplicationForParticipant(
+        @PathVariable("expo_id") String expoId,
+        @RequestBody @Valid ApplicationForParticipantRequestDto dto
+    ) {
         preApplicationForParticipantService.execute(expoId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PostMapping("/field/{expo_id}")
-    public ResponseEntity<Void> fieldApplicationForTrainee(@PathVariable("expo_id") String expoId, @RequestBody @Valid ApplicationForTraineeRequestDto dto) {
+    public ResponseEntity<Void> fieldApplicationForTrainee(
+        @PathVariable("expo_id") String expoId,
+        @RequestBody @Valid ApplicationForTraineeRequestDto dto
+    ) {
         fieldApplicationForTraineeService.execute(expoId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PostMapping("/field/standard/{expo_id}")
-    public ResponseEntity<Void> fieldApplicationForParticipant(@PathVariable("expo_id") String expoId, @RequestBody @Valid ApplicationForParticipantRequestDto dto) {
+    public ResponseEntity<Void> fieldApplicationForParticipant(
+        @PathVariable("expo_id") String expoId,
+        @RequestBody @Valid ApplicationForParticipantRequestDto dto
+    ) {
         fieldApplicationForParticipantService.execute(expoId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PostMapping("/field/temporary/{expo_id}")
-    public ResponseEntity<ApplicationTemporaryQrResponseDto> fieldApplicationTemporaryQr(@PathVariable("expo_id") String expoId, @RequestBody @Valid ApplicationTemporaryQrRequestDto dto) {
+    public ResponseEntity<ApplicationTemporaryQrResponseDto> fieldApplicationTemporaryQr(
+        @PathVariable("expo_id") String expoId,
+        @RequestBody @Valid ApplicationTemporaryQrRequestDto dto
+    ) {
         ApplicationTemporaryQrResponseDto response = fieldApplicationTemporaryQrService.execute(expoId, dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
@@ -55,18 +55,19 @@ public class FieldApplicationForParticipantServiceImpl implements FieldApplicati
     }
 
     private void saveParticipant(Expo expo, ApplicationForParticipantRequestDto dto) {
-        StandardParticipant standardParticipant = StandardParticipant.builder()
-                .name(dto.getName())
-                .phoneNumber(dto.getPhoneNumber())
-                .authority(Authority.ROLE_STANDARD)
-                .affiliation(dto.getAffiliation())
-                .schoolLevel(dto.getSchoolLevel())
-                .schoolDetail(dto.getSchoolDetail())
-                .informationJson(dto.getInformationJson())
-                .applicationType(ApplicationType.FIELD)
-                .personalInformationStatus(dto.getPersonalInformationStatus())
-                .expo(expo)
-                .build();
+        StandardParticipant standardParticipant = standardParticipantRepository.findByPhoneNumberAndExpoForWrite(dto.getPhoneNumber(), expo)
+                .orElse(StandardParticipant.builder()
+                        .name(dto.getName())
+                        .phoneNumber(dto.getPhoneNumber())
+                        .authority(Authority.ROLE_STANDARD)
+                        .affiliation(dto.getAffiliation())
+                        .schoolLevel(dto.getSchoolLevel())
+                        .schoolDetail(dto.getSchoolDetail())
+                        .informationJson(dto.getInformationJson())
+                        .applicationType(ApplicationType.FIELD)
+                        .personalInformationStatus(dto.getPersonalInformationStatus())
+                        .expo(expo)
+                        .build());
 
         standardParticipantRepository.save(standardParticipant);
     }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForTraineeServiceImpl.java
@@ -50,16 +50,17 @@ public class FieldApplicationForTraineeServiceImpl implements FieldApplicationFo
     }
 
     private void saveTrainee(ApplicationForTraineeRequestDto dto, Expo expo) {
-        Trainee trainee = Trainee.builder()
-                .trainingId(dto.getTrainingId())
-                .phoneNumber(dto.getPhoneNumber())
-                .authority(Authority.ROLE_TRAINEE)
-                .name(dto.getName())
-                .applicationType(ApplicationType.FIELD)
-                .informationJson(dto.getInformationJson())
-                .personalInformationStatus(dto.getPersonalInformationStatus())
-                .expo(expo)
-                .build();
+        Trainee trainee = traineeRepository.findByPhoneNumberAndExpoForWrite(dto.getPhoneNumber(), expo)
+                .orElse(Trainee.builder()
+                        .trainingId(dto.getTrainingId())
+                        .phoneNumber(dto.getPhoneNumber())
+                        .authority(Authority.ROLE_TRAINEE)
+                        .name(dto.getName())
+                        .applicationType(ApplicationType.PRE)
+                        .informationJson(dto.getInformationJson())
+                        .personalInformationStatus(dto.getPersonalInformationStatus())
+                        .expo(expo)
+                        .build());
 
         traineeRepository.save(trainee);
     }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
@@ -55,18 +55,19 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
     }
 
     private void saveParticipant(Expo expo, ApplicationForParticipantRequestDto dto) {
-        StandardParticipant standardParticipant = StandardParticipant.builder()
-                .name(dto.getName())
-                .phoneNumber(dto.getPhoneNumber())
-                .authority(Authority.ROLE_STANDARD)
-                .affiliation(dto.getAffiliation())
-                .schoolLevel(dto.getSchoolLevel())
-                .schoolDetail(dto.getSchoolDetail())
-                .informationJson(dto.getInformationJson())
-                .applicationType(ApplicationType.PRE)
-                .personalInformationStatus(dto.getPersonalInformationStatus())
-                .expo(expo)
-                .build();
+        StandardParticipant standardParticipant = standardParticipantRepository.findByPhoneNumberAndExpoForWrite(dto.getPhoneNumber(), expo)
+                .orElse(StandardParticipant.builder()
+                        .name(dto.getName())
+                        .phoneNumber(dto.getPhoneNumber())
+                        .authority(Authority.ROLE_STANDARD)
+                        .affiliation(dto.getAffiliation())
+                        .schoolLevel(dto.getSchoolLevel())
+                        .schoolDetail(dto.getSchoolDetail())
+                        .informationJson(dto.getInformationJson())
+                        .applicationType(ApplicationType.FIELD)
+                        .personalInformationStatus(dto.getPersonalInformationStatus())
+                        .expo(expo)
+                        .build());
 
         standardParticipantRepository.save(standardParticipant);
     }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
@@ -50,16 +50,17 @@ public class PreApplicationForTraineeServiceImpl implements PreApplicationForTra
     }
 
     private void saveTrainee(ApplicationForTraineeRequestDto dto, Expo expo) {
-        Trainee trainee = Trainee.builder()
-                .trainingId(dto.getTrainingId())
-                .phoneNumber(dto.getPhoneNumber())
-                .authority(Authority.ROLE_TRAINEE)
-                .name(dto.getName())
-                .applicationType(ApplicationType.PRE)
-                .informationJson(dto.getInformationJson())
-                .personalInformationStatus(dto.getPersonalInformationStatus())
-                .expo(expo)
-                .build();
+        Trainee trainee = traineeRepository.findByPhoneNumberAndExpoForWrite(dto.getPhoneNumber(), expo)
+                .orElse(Trainee.builder()
+                        .trainingId(dto.getTrainingId())
+                        .phoneNumber(dto.getPhoneNumber())
+                        .authority(Authority.ROLE_TRAINEE)
+                        .name(dto.getName())
+                        .applicationType(ApplicationType.PRE)
+                        .informationJson(dto.getInformationJson())
+                        .personalInformationStatus(dto.getPersonalInformationStatus())
+                        .expo(expo)
+                        .build());
 
         traineeRepository.save(trainee);
     }

--- a/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantRepository.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantRepository.java
@@ -1,6 +1,8 @@
 package team.startup.expo.domain.participant.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
@@ -10,16 +12,28 @@ import java.util.List;
 import java.util.Optional;
 
 public interface StandardParticipantRepository extends JpaRepository<StandardParticipant, Long> {
+
     Optional<StandardParticipant> findByPhoneNumberAndExpo(String phoneNumber, Expo expo);
+
     void deleteByExpo(Expo expo);
+
     @Query("SELECT sp FROM StandardParticipant sp " +
             "JOIN sp.expo e " +
             "WHERE e = :expo " +
             "AND sp.applicationType = :applicationType " +
             "AND sp.name LIKE %:name%")
     List<StandardParticipant> findByExpoAndApplicationTypeAndName(Expo expo, ApplicationType applicationType, String name);
+
     List<StandardParticipant> findByExpoAndApplicationType(Expo expo, ApplicationType applicationType);
+
+
     Boolean existsByPhoneNumberAndExpo(String phoneNumber, Expo expo);
+
     List<StandardParticipant> findByExpo(Expo expo);
+
     Boolean existsByPhoneNumber(String phoneNumber);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT sp FROM StandardParticipant sp WHERE sp.phoneNumber=:phoneNumber AND sp.expo=:expo")
+    Optional<StandardParticipant> findByPhoneNumberAndExpoForWrite(String phoneNumber, Expo expo);
 }

--- a/src/main/java/team/startup/expo/domain/trainee/repository/TraineeRepository.java
+++ b/src/main/java/team/startup/expo/domain/trainee/repository/TraineeRepository.java
@@ -1,6 +1,8 @@
 package team.startup.expo.domain.trainee.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.trainee.entity.Trainee;
@@ -9,14 +11,24 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TraineeRepository extends JpaRepository<Trainee, Long> {
+
     Optional<Trainee> findByPhoneNumberAndExpo(String phoneNumber, Expo expo);
+
     List<Trainee> findByExpo(Expo expo);
+
     @Query("SELECT t FROM Trainee t " +
             "JOIN t.expo e " +
             "WHERE e = :expo " +
             "AND t.name LIKE %:name%")
     List<Trainee> findByExpoAndName(Expo expo, String name);
+
     void deleteByExpo(Expo expo);
+
     Boolean existsByPhoneNumberAndExpo(String phoneNumber, Expo expo);
+
     Optional<Trainee> findByTrainingId(String trainingId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM Trainee t WHERE t.phoneNumber=:phoneNumber AND t.expo=:expo")
+    Optional<Trainee> findByPhoneNumberAndExpoForWrite(String phoneNumber, Expo expo);
 }


### PR DESCRIPTION
## 💡 배경 및 개요

박람회 사전/현장 신청 API에서 row lock을 적용하였습니다.

Resolves: #257 

## 📃 작업내용

해당 expo에서 trainee, standardParticipant 가 전화번호와 같은 것이 있는지 검증 후 save하기 전 row lock을 걸어 쿼리를 날리고 저장하게 하였습니다

## 🙋‍♂️ 리뷰노트

trainee 혹은 standardParticipant에서 쿼리를 같이 exist를 날리지 않으면 최적화가 가능할 것 같습니다. 추후 확인 후 변경하겠습니다

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타