### PR TITLE
🔀 :: 박람회 입장/퇴장 30초 이후 가능하게 적용 및 row lock 적용

### DIFF
--- a/src/main/java/team/startup/expo/domain/attendance/entity/LeaveManager.java
+++ b/src/main/java/team/startup/expo/domain/attendance/entity/LeaveManager.java
@@ -1,0 +1,34 @@
+package team.startup.expo.domain.attendance.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+import team.startup.expo.domain.form.entity.ParticipationType;
+
+@RedisHash(value = "leave_manager", timeToLive = 30L)
+@Builder
+@Getter
+public class LeaveManager {
+    @Id
+    private String phoneNumber;
+    @Indexed
+    private String expoId;
+    private ParticipationType participationType;
+
+
+}
+
+
+
+//@RedisHash(value = "phone_authentication", timeToLive = 60L * 3)
+//@Builder
+//@Getter
+//public class SmsAuthEntity {
+//    @Id
+//    private String phone;
+//    @Indexed
+//    private String randomValue;
+//    private Boolean authentication;
+//    private Integer attemptCount;

--- a/src/main/java/team/startup/expo/domain/attendance/exception/NotEnterAfterThirtySecondException.java
+++ b/src/main/java/team/startup/expo/domain/attendance/exception/NotEnterAfterThirtySecondException.java
@@ -1,0 +1,11 @@
+package team.startup.expo.domain.attendance.exception;
+
+import team.startup.expo.global.exception.GlobalException;
+
+import static team.startup.expo.global.exception.ErrorCode.NOT_ENTER_AFTER_THIRTY_SECOND;
+
+public class NotEnterAfterThirtySecondException extends GlobalException {
+    public NotEnterAfterThirtySecondException() {
+        super(NOT_ENTER_AFTER_THIRTY_SECOND);
+    }
+}

--- a/src/main/java/team/startup/expo/domain/attendance/repository/LeaveManagerRepository.java
+++ b/src/main/java/team/startup/expo/domain/attendance/repository/LeaveManagerRepository.java
@@ -1,0 +1,7 @@
+package team.startup.expo.domain.attendance.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import team.startup.expo.domain.attendance.entity.LeaveManager;
+
+public interface LeaveManagerRepository extends CrudRepository<LeaveManager, String> {
+}

--- a/src/main/java/team/startup/expo/domain/attendance/service/impl/PreEnterScanQrCodeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/attendance/service/impl/PreEnterScanQrCodeServiceImpl.java
@@ -112,7 +112,7 @@ public class PreEnterScanQrCodeServiceImpl implements PreEnterScanQrCodeService 
                 .orElseThrow(NotFoundTraineeException::new);
 
         Optional<TraineeParticipation> traineeParticipation =
-                traineeParticipationRepository.findByExpoAndTraineeAndAttendanceDate(expo, trainee, LocalDate.now());
+                traineeParticipationRepository.findByExpoAndTraineeAndAttendanceDateForWrite(expo, trainee, LocalDate.now());
 
         if (leaveManagerRepository.existsById(trainee.getPhoneNumber())) {
             throw new NotEnterAfterThirtySecondException();

--- a/src/main/java/team/startup/expo/domain/attendance/service/impl/PreEnterScanQrCodeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/attendance/service/impl/PreEnterScanQrCodeServiceImpl.java
@@ -61,7 +61,11 @@ public class PreEnterScanQrCodeServiceImpl implements PreEnterScanQrCodeService 
                 .orElseThrow(NotFoundParticipantException::new);
 
         Optional<StandardParticipantParticipation> standardParticipantParticipation =
-                standardParticipantParticipationRepository.findByExpoAndStandardParticipantAndAttendanceDate(expo, standardParticipant, LocalDate.now());
+                standardParticipantParticipationRepository.findByExpoAndStandardParticipantAndAttendanceDateForWrite(expo, standardParticipant, LocalDate.now());
+
+        if (leaveManagerRepository.existsById(standardParticipant.getPhoneNumber())) {
+            throw new NotEnterAfterThirtySecondException();
+        }
 
         if (standardParticipantParticipation.isPresent()) {
             StandardParticipantParticipation getStandardParticipantParticipation = standardParticipantParticipation.get();

--- a/src/main/java/team/startup/expo/domain/form/entity/ParticipationType.java
+++ b/src/main/java/team/startup/expo/domain/form/entity/ParticipationType.java
@@ -1,5 +1,10 @@
 package team.startup.expo.domain.form.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public enum ParticipationType {
-    TRAINEE, STANDARD
+    @JsonProperty("TRAINEE")
+    TRAINEE,
+    @JsonProperty("STANDARD")
+    STANDARD
 }

--- a/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantParticipationRepository.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantParticipationRepository.java
@@ -1,6 +1,9 @@
 package team.startup.expo.domain.participant.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.participant.entity.StandardParticipantParticipation;
@@ -9,5 +12,11 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 public interface StandardParticipantParticipationRepository extends JpaRepository<StandardParticipantParticipation, Long> {
-    Optional<StandardParticipantParticipation> findByExpoAndStandardParticipantAndAttendanceDate(Expo expo, StandardParticipant standardParticipant, LocalDate attendanceDate);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT spp FROM StandardParticipantParticipation spp " +
+            "WHERE spp.expo=:expo " +
+            "AND spp.standardParticipant=:standardParticipant " +
+            "AND spp.attendanceDate=:attendanceDate")
+    Optional<StandardParticipantParticipation> findByExpoAndStandardParticipantAndAttendanceDateForWrite(Expo expo, StandardParticipant standardParticipant, LocalDate attendanceDate);
 }

--- a/src/main/java/team/startup/expo/domain/trainee/repository/TraineeParticipationRepository.java
+++ b/src/main/java/team/startup/expo/domain/trainee/repository/TraineeParticipationRepository.java
@@ -1,6 +1,9 @@
 package team.startup.expo.domain.trainee.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.trainee.entity.Trainee;
 import team.startup.expo.domain.trainee.entity.TraineeParticipation;
@@ -9,5 +12,11 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 public interface TraineeParticipationRepository extends JpaRepository<TraineeParticipation, Long> {
-    Optional<TraineeParticipation> findByExpoAndTraineeAndAttendanceDate(Expo expo, Trainee trainee, LocalDate attendanceDate);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT tp " +
+            "FROM TraineeParticipation tp " +
+            "WHERE tp.expo=:expo " +
+            "AND tp.trainee=:trainee AND tp.attendanceDate=:attendanceDate")
+    Optional<TraineeParticipation> findByExpoAndTraineeAndAttendanceDateForWrite(Expo expo, Trainee trainee, LocalDate attendanceDate);
 }

--- a/src/main/java/team/startup/expo/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/expo/global/exception/ErrorCode.java
@@ -62,6 +62,7 @@ public enum ErrorCode {
 
     // attendance
     ALREADY_ENTER_EXPO_USER(400, "이미 박람회에 입장한 유저입니다."),
+    NOT_ENTER_AFTER_THIRTY_SECOND(401, "입장 후 30초가 지나지 않았습니다."),
 
     // trainee
     NOT_FOUND_TRAINEE(404, "연수자를 찾지 못 했습니다."),


### PR DESCRIPTION
## 💡 배경 및 개요

박람회를 입장 한 시점에서 30초 이후부터 퇴장이 가능하도록 redis를 이용하여 구현하였고 Participation 엔티티들을 조회할 때 row lock을 걸어 동시성 문제가 터지지 않도록 하였습니다.

Resolves: #260 

## 📃 작업내용

* findByExpoAndTraineeAndAttendanceDateForWrite method row lock confirm
* findByExpoAndStandardParticipantAndAttendanceDateForWrite method row lock confirm
* 
## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타