### PR TITLE
🔀 :: 참가자 불러오기 페이징 문제

### DIFF
--- a/src/main/java/team/startup/expo/domain/participant/presentation/ParticipantController.java
+++ b/src/main/java/team/startup/expo/domain/participant/presentation/ParticipantController.java
@@ -24,7 +24,7 @@ public class ParticipantController {
             @RequestParam(value = "page", defaultValue = "0", required = false) int page,
             @RequestParam(value = "date", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
-        PageRequest pageable = PageRequest.of(page - 1 >= 0 ? page : 0, size);
+        PageRequest pageable = PageRequest.of(page, size);
 
         ParticipantResponseDto response = getParticipantInfoService.execute(expoId, pageable, date);
         return ResponseEntity.ok(response);

--- a/src/main/java/team/startup/expo/domain/participant/service/impl/GetParticipantInfoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/participant/service/impl/GetParticipantInfoServiceImpl.java
@@ -23,8 +23,7 @@ public class GetParticipantInfoServiceImpl implements GetParticipantInfoService 
     private final ParticipantCustomRepository participantRepositoryCustom;
     private final ExpoRepository expoRepository;
 
-    public ParticipantResponseDto execute(
-            String expoId, Pageable pageable, LocalDate date) {
+    public ParticipantResponseDto execute(String expoId, Pageable pageable, LocalDate date) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
@@ -32,7 +31,7 @@ public class GetParticipantInfoServiceImpl implements GetParticipantInfoService 
 
         LocalDate targetDate = date != null ? date : LocalDate.now();
 
-        validateDateRange(expoId, date);
+        validateDateRange(expoId, targetDate);
 
         return participantRepositoryCustom.searchParticipants(expo.getId(), pageable, targetDate);
 


### PR DESCRIPTION
## 💡 배경 및 개요

참가자를 불러올 때 페이징의 정보가 잘못되어 정상적으로 불러와지지 않는 문제를 해결하였습니다.

Resolves: 

## 📃 작업내용

* searchParticipants 로직 변경

## 🙋‍♂️ 리뷰노트

totalElement를 초기화 할 때 기존의 방식으로 초기화가 되지 않아 query를 날려 count를 넣어 초기화하는 방식으로 변경하였습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타