### PR TITLE
🔀 :: 참가자 정보 엑셀 출력 및 만족도 조사 결과 동시 출력

### DIFF
--- a/src/main/java/team/startup/expo/domain/survey/answer/repository/StandardParticipantSurveyAnswerRepository.java
+++ b/src/main/java/team/startup/expo/domain/survey/answer/repository/StandardParticipantSurveyAnswerRepository.java
@@ -1,9 +1,14 @@
 package team.startup.expo.domain.survey.answer.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.survey.answer.entity.StandardParticipantSurveyAnswer;
 
+import java.util.List;
+
 public interface StandardParticipantSurveyAnswerRepository extends JpaRepository<StandardParticipantSurveyAnswer, Long> {
     Boolean existsByStandardParticipant(StandardParticipant standardParticipant);
+    @Query("SELECT spsa FROM StandardParticipantSurveyAnswer spsa WHERE spsa.standardParticipant.id IN :standardParticipantIds")
+    List<StandardParticipantSurveyAnswer> findStandardParticipantSurveyAnswersByStandardParticipantIds(List<Long> standardParticipantIds);
 }


### PR DESCRIPTION
## 💡 배경 및 개요

참가자의 정보를 엑셀로 출력하는 동시에 만족도 조사를 완료하면 같이 엑셀 출력이 가능하도록 하였습니다.

Resolves: #{이슈번호}

## 📃 작업내용

* standardParticipantInfoToExcel 에 만족도 조사 결과 추가 반환

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타