### PR TITLE
🔀 :: 설문조사 완료시 행운의 숫자 당첨 여부 반환

### DIFF
--- a/src/main/java/team/startup/expo/domain/survey/answer/entity/Draw.java
+++ b/src/main/java/team/startup/expo/domain/survey/answer/entity/Draw.java
@@ -1,0 +1,48 @@
+package team.startup.expo.domain.survey.answer.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum Draw {
+
+    THIRTY(30, "정보원 건물 번호"),
+    SIXTY_TWO(62, "광주 지역번호"),
+    SEVENTY_ONE(71, "프로그램 참여 학교 수"),
+    ONE_HUNDRED_ELEVEN(111, "정보원 주소 189번길"),
+    ONE_HUNDRED_EIGHTY_NINE(189, "정보원 주소 189번길"),
+    TWO_HUNDRED_NINE(209, "학급 수"),
+    FIVE_HUNDRED_TWENTY_FOUR(524, "축전 날짜"),
+    SEVEN_HUNDRED_SEVENTY_SEVEN(777, "행운의 번호"),
+    ONE_THOUSAND_ONE(1001, "0과 1로 이루어진 코드"),
+    ONE_THOUSAND_TEN(1010, "0과 1로 이루어진 코드"),
+    ONE_THOUSAND_ONE_HUNDRED(1100, "0과 1로 이루어진 코드"),
+    ONE_THOUSAND_TWO_HUNDRED_THIRTY_FOUR(1234, "순차번호"),
+    ONE_THOUSAND_EIGHT_HUNDRED_NINETY_THREE(1893, "정보원 길, 건물번호"),
+    TWO_THOUSAND(2000, "밀레니엄"),
+    TWO_THOUSAND_TWENTY_FIVE(2025, "올해 연도"),
+    TWO_THOUSAND_TWO_HUNDRED_TWENTY_TWO(2222, "반복되는 숫자"),
+    THREE_THOUSAND_THREE_HUNDRED_THIRTY_THREE(3333, "반복되는 숫자"),
+    THREE_THOUSAND_EIGHT_HUNDRED(3800, "정보원 국번 380"),
+    FOUR_THOUSAND_FOUR_HUNDRED_FORTY_FOUR(4444, "반복되는 숫자"),
+    FOUR_THOUSAND_SEVEN_HUNDRED_SIXTY(4760, "정보원 전화번호"),
+    FIVE_THOUSAND(5000, "중간"),
+    FIVE_THOUSAND_FIVE_HUNDRED_FIFTY_FIVE(5555, "반복되는 숫자"),
+    FIVE_THOUSAND_SIX_HUNDRED_SEVENTY_FOUR(5674, "정보원 전화번호 뒷자리"),
+    SIX_THOUSAND_SIX_HUNDRED_SIXTY_SIX(6666, "반복되는 숫자"),
+    SIX_THOUSAND_SIX_HUNDRED_SEVENTY_FOUR(6674, "정보원 전화번호 뒷자리"),
+    SEVEN_THOUSAND_ONE_HUNDRED_SEVENTY(7170, "1학기 프로그램 종료일"),
+    SEVEN_THOUSAND_SIX_HUNDRED_SEVENTY_FOUR(7674, "정보원 전화번호 뒷자리"),
+    SEVEN_THOUSAND_SEVEN_HUNDRED_SEVENTY_SEVEN(7777, "코드 느낌"),
+    EIGHT_THOUSAND_SIX_HUNDRED_SEVENTY_FOUR(8674, "정보원 전화번호 뒷자리"),
+    EIGHT_THOUSAND_EIGHT_HUNDRED_EIGHTY_EIGHT(8888, "반복되는 숫자"),
+    NINE_THOUSAND_SIX_HUNDRED_SEVENTY_FOUR(9674, "정보원 전화번호 뒷자리"),
+    NINE_THOUSAND_NINE_HUNDRED_NINETY_NINE(9999, "반복되는 숫자"),
+    TEN_THOUSAND(10000, "끝");
+
+    private final Integer number;
+    private final String reason;
+}

--- a/src/main/java/team/startup/expo/domain/survey/answer/presentation/SurveyAnswerController.java
+++ b/src/main/java/team/startup/expo/domain/survey/answer/presentation/SurveyAnswerController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team.startup.expo.domain.survey.answer.presentation.dto.request.SurveyAnswerRequestDto;
+import team.startup.expo.domain.survey.answer.presentation.dto.response.StandardSurveyAnswerResponseDto;
 import team.startup.expo.domain.survey.answer.service.StandardSurveyAnswerService;
 import team.startup.expo.domain.survey.answer.service.TraineeSurveyAnswerService;
 
@@ -18,9 +19,9 @@ public class SurveyAnswerController {
     private final TraineeSurveyAnswerService traineeSurveyAnswerService;
 
     @PostMapping("/standard/{expo_id}")
-    public ResponseEntity<Void> standardSurveyAnswer(@PathVariable("expo_id") String expoId, @Valid @RequestBody SurveyAnswerRequestDto dto) {
-        standardSurveyAnswerService.execute(expoId, dto);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+    public ResponseEntity<StandardSurveyAnswerResponseDto> standardSurveyAnswer(@PathVariable("expo_id") String expoId, @Valid @RequestBody SurveyAnswerRequestDto dto) {
+        StandardSurveyAnswerResponseDto response = standardSurveyAnswerService.execute(expoId, dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PostMapping("/trainee/{expo_id}")

--- a/src/main/java/team/startup/expo/domain/survey/answer/presentation/dto/response/StandardSurveyAnswerResponseDto.java
+++ b/src/main/java/team/startup/expo/domain/survey/answer/presentation/dto/response/StandardSurveyAnswerResponseDto.java
@@ -1,0 +1,12 @@
+package team.startup.expo.domain.survey.answer.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StandardSurveyAnswerResponseDto {
+    private Boolean drawStatus;
+    private Integer drawNumber;
+    private String drawReason;
+}

--- a/src/main/java/team/startup/expo/domain/survey/answer/repository/StandardParticipantSurveyAnswerRepository.java
+++ b/src/main/java/team/startup/expo/domain/survey/answer/repository/StandardParticipantSurveyAnswerRepository.java
@@ -1,6 +1,8 @@
 package team.startup.expo.domain.survey.answer.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.survey.answer.entity.StandardParticipantSurveyAnswer;
@@ -9,6 +11,11 @@ import java.util.List;
 
 public interface StandardParticipantSurveyAnswerRepository extends JpaRepository<StandardParticipantSurveyAnswer, Long> {
     Boolean existsByStandardParticipant(StandardParticipant standardParticipant);
+
     @Query("SELECT spsa FROM StandardParticipantSurveyAnswer spsa WHERE spsa.standardParticipant.id IN :standardParticipantIds")
     List<StandardParticipantSurveyAnswer> findStandardParticipantSurveyAnswersByStandardParticipantIds(List<Long> standardParticipantIds);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT spsa FROM StandardParticipantSurveyAnswer spsa WHERE spsa.standardParticipant = :standardParticipant")
+    StandardParticipantSurveyAnswer findByStandardParticipantForWrite(StandardParticipant standardParticipant);
 }

--- a/src/main/java/team/startup/expo/domain/survey/answer/service/StandardSurveyAnswerService.java
+++ b/src/main/java/team/startup/expo/domain/survey/answer/service/StandardSurveyAnswerService.java
@@ -1,7 +1,8 @@
 package team.startup.expo.domain.survey.answer.service;
 
 import team.startup.expo.domain.survey.answer.presentation.dto.request.SurveyAnswerRequestDto;
+import team.startup.expo.domain.survey.answer.presentation.dto.response.StandardSurveyAnswerResponseDto;
 
 public interface StandardSurveyAnswerService {
-    void execute(String expoId, SurveyAnswerRequestDto dto);
+    StandardSurveyAnswerResponseDto execute(String expoId, SurveyAnswerRequestDto dto);
 }

--- a/src/main/java/team/startup/expo/domain/survey/answer/service/impl/StandardSurveyAnswerServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/answer/service/impl/StandardSurveyAnswerServiceImpl.java
@@ -4,14 +4,20 @@ import lombok.RequiredArgsConstructor;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.form.entity.ParticipationType;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.sms.exception.NotFoundParticipantException;
+import team.startup.expo.domain.survey.answer.entity.Draw;
 import team.startup.expo.domain.survey.answer.entity.StandardParticipantSurveyAnswer;
 import team.startup.expo.domain.survey.answer.exception.AlreadyExistSurveyAnswerException;
 import team.startup.expo.domain.survey.answer.presentation.dto.request.SurveyAnswerRequestDto;
+import team.startup.expo.domain.survey.answer.presentation.dto.response.StandardSurveyAnswerResponseDto;
 import team.startup.expo.domain.survey.answer.repository.StandardParticipantSurveyAnswerRepository;
 import team.startup.expo.domain.survey.answer.service.StandardSurveyAnswerService;
+import team.startup.expo.domain.survey.management.entity.Survey;
+import team.startup.expo.domain.survey.management.exception.NotFoundSurveyException;
+import team.startup.expo.domain.survey.management.repository.SurveyRepository;
 import team.startup.expo.global.annotation.TransactionService;
 
 @TransactionService
@@ -21,8 +27,9 @@ public class StandardSurveyAnswerServiceImpl implements StandardSurveyAnswerServ
     private final StandardParticipantSurveyAnswerRepository standardparticipantSurveyAnswerRepository;
     private final StandardParticipantRepository participantRepository;
     private final ExpoRepository expoRepository;
+    private final SurveyRepository surveyRepository;
 
-    public void execute(String expoId, SurveyAnswerRequestDto dto) {
+    public StandardSurveyAnswerResponseDto execute(String expoId, SurveyAnswerRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
@@ -33,9 +40,21 @@ public class StandardSurveyAnswerServiceImpl implements StandardSurveyAnswerServ
             throw new AlreadyExistSurveyAnswerException();
 
         saveSurveyAnswer(dto, standardParticipant);
+
+        return processDraw(expo);
+
     }
 
-    private void saveSurveyAnswer(SurveyAnswerRequestDto dto, StandardParticipant standardParticipant) {
+    private void saveSurveyAnswer(
+        SurveyAnswerRequestDto dto,
+        StandardParticipant standardParticipant
+    ) {
+        StandardParticipantSurveyAnswer standardSurveyAnswer =
+                standardparticipantSurveyAnswerRepository.findByStandardParticipantForWrite(standardParticipant);
+
+        if (standardSurveyAnswer != null)
+            throw new AlreadyExistSurveyAnswerException();
+
         StandardParticipantSurveyAnswer surveyAnswer = StandardParticipantSurveyAnswer.builder()
                 .answerJson(dto.getAnswerJson())
                 .standardParticipant(standardParticipant)
@@ -43,5 +62,39 @@ public class StandardSurveyAnswerServiceImpl implements StandardSurveyAnswerServ
                 .build();
 
         standardparticipantSurveyAnswerRepository.save(surveyAnswer);
+
+    }
+
+    private StandardSurveyAnswerResponseDto processDraw(Expo expo) {
+        Survey survey = surveyRepository.findByExpoAndParticipationType(expo, ParticipationType.STANDARD)
+                .orElseThrow(NotFoundSurveyException::new);
+
+        survey.plusTotalAnswer();
+
+        surveyRepository.save(survey);
+
+        int nowNumber = survey.getTotalAnswers();
+
+        StandardSurveyAnswerResponseDto responseDto = null;
+        for (Draw draw : Draw.values()) {
+            if (draw.getNumber().equals(nowNumber)) {
+                responseDto = StandardSurveyAnswerResponseDto.builder()
+                        .drawStatus(true)
+                        .drawNumber(draw.getNumber())
+                        .drawReason(draw.getReason())
+                        .build();
+            }
+        }
+
+        if (responseDto == null) {
+            responseDto = StandardSurveyAnswerResponseDto.builder()
+                    .drawStatus(false)
+                    .drawNumber(nowNumber)
+                    .drawReason("아쉽게 행운의 숫자에 당첨되지 않았습니다.")
+                    .build();
+        }
+
+        return responseDto;
+
     }
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/entity/Survey.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/entity/Survey.java
@@ -34,8 +34,14 @@ public class Survey {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Expo expo;
 
+    private Integer totalAnswers;
+
     public void update(String informationText) {
         this.informationText = informationText;
+    }
+
+    public void plusTotalAnswer() {
+        this.totalAnswers++;
     }
 }
 

--- a/src/main/java/team/startup/expo/domain/survey/management/repository/SurveyRepository.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/repository/SurveyRepository.java
@@ -13,5 +13,4 @@ public interface SurveyRepository extends JpaRepository<Survey, Long> {
     Optional<Survey> findByExpoAndParticipationType(Expo expo, ParticipationType participationType);
     List<Survey> findByExpo(Expo expo);
     void deleteByExpo(Expo expo);
-    boolean existsByExpo(Expo expo);
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/service/impl/CreateSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/impl/CreateSurveyServiceImpl.java
@@ -38,6 +38,7 @@ public class CreateSurveyServiceImpl implements CreateSurveyService {
                 .participationType(dto.getParticipationType())
                 .informationText(dto.getInformationText())
                 .expo(expo)
+                .totalAnswers(0)
                 .build();
 
         return surveyRepository.save(survey);


### PR DESCRIPTION
## 💡 배경 및 개요

설문조사 완료시 행운의 숫자 당첨 여부를 반환할 수 있게 로직을 추가하였습니다.

Resolves: #{이슈번호}

## 📃 작업내용

* Survey에 totalAnswers 추가
* Draw Enum 추가
* 일반 참가자 설문조사 참여 후 당첨 여부 반환 로직 추가

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타