### PR TITLE
🔀 :: 박람회별 등록자 수 통계 알림

### DIFF
--- a/src/main/java/team/startup/expo/domain/alarm/presentation/AlarmController.java
+++ b/src/main/java/team/startup/expo/domain/alarm/presentation/AlarmController.java
@@ -1,0 +1,26 @@
+package team.startup.expo.domain.alarm.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import team.startup.expo.domain.alarm.service.SaveYesterdayPersonService;
+import team.startup.expo.domain.alarm.service.SendParticipantNumberByExpoService;
+
+@Component
+@RequiredArgsConstructor
+public class AlarmController {
+
+    private final SendParticipantNumberByExpoService sendParticipantNumberByExpoService;
+    private final SaveYesterdayPersonService saveYesterdayPersonService;
+
+    @Scheduled(cron = "0 0 8,12,16,20 * * *")
+    public void sendParticipantNumberByExpo() {
+        sendParticipantNumberByExpoService.execute();
+    }
+
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void saveYesterdayPerson() {
+        saveYesterdayPersonService.execute();
+    }
+}

--- a/src/main/java/team/startup/expo/domain/alarm/service/SaveYesterdayPersonService.java
+++ b/src/main/java/team/startup/expo/domain/alarm/service/SaveYesterdayPersonService.java
@@ -1,0 +1,5 @@
+package team.startup.expo.domain.alarm.service;
+
+public interface SaveYesterdayPersonService {
+    void execute();
+}

--- a/src/main/java/team/startup/expo/domain/alarm/service/SendParticipantNumberByExpoService.java
+++ b/src/main/java/team/startup/expo/domain/alarm/service/SendParticipantNumberByExpoService.java
@@ -1,0 +1,5 @@
+package team.startup.expo.domain.alarm.service;
+
+public interface SendParticipantNumberByExpoService {
+    void execute();
+}

--- a/src/main/java/team/startup/expo/domain/alarm/service/impl/SaveYesterdayPersonServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/alarm/service/impl/SaveYesterdayPersonServiceImpl.java
@@ -1,0 +1,25 @@
+package team.startup.expo.domain.alarm.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import team.startup.expo.domain.alarm.service.SaveYesterdayPersonService;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.global.annotation.TransactionService;
+
+import java.util.List;
+
+@TransactionService
+@RequiredArgsConstructor
+public class SaveYesterdayPersonServiceImpl implements SaveYesterdayPersonService {
+
+    private final ExpoRepository expoRepository;
+
+    public void execute() {
+        List<Expo> expoList = expoRepository.findAll();
+
+        expoList.forEach(expo -> {
+            expo.saveYesterdayApplicationPerson(expo.getApplicationPerson());
+            expoRepository.save(expo);
+        });
+    }
+}

--- a/src/main/java/team/startup/expo/domain/alarm/service/impl/SendParticipantNumberByExpoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/alarm/service/impl/SendParticipantNumberByExpoServiceImpl.java
@@ -1,0 +1,75 @@
+package team.startup.expo.domain.alarm.service.impl;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestTemplate;
+import team.startup.expo.domain.alarm.service.SendParticipantNumberByExpoService;
+import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.global.annotation.ReadOnlyTransactionService;
+import team.startup.expo.global.thirdparty.discord.properties.DiscordProperties;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@ReadOnlyTransactionService
+@RequiredArgsConstructor
+public class SendParticipantNumberByExpoServiceImpl implements SendParticipantNumberByExpoService {
+
+    private final DiscordProperties discordProperties;
+    private final ExpoRepository expoRepository;
+
+    public void execute() {
+        List<Expo> expoList = expoRepository.findAll();
+
+        expoList.forEach(expo -> {
+            JsonObject statusField = new JsonObject();
+            statusField.add("name", new JsonPrimitive("박람회 이름"));
+            statusField.add("value", new JsonPrimitive(expo.getTitle()));
+
+            JsonObject yesterdayPersonField = new JsonObject();
+            yesterdayPersonField.add("name", new JsonPrimitive("어제 박람회 등록 인원"));
+            yesterdayPersonField.add("value", new JsonPrimitive(expo.getYesterdayApplicationPerson()));
+
+            JsonObject nowPersonField = new JsonObject();
+            nowPersonField.add("name", new JsonPrimitive(LocalDate.now() + " 기준 현재 박람회 등록 인원"));
+            nowPersonField.add("value", new JsonPrimitive(expo.getApplicationPerson()));
+
+            String yesterdayAndTodayPersonDifference = String.valueOf(expo.getApplicationPerson() - expo.getYesterdayApplicationPerson());
+
+            JsonObject yesterdayAndTodayPersonDifferenceField = new JsonObject();
+            yesterdayAndTodayPersonDifferenceField.add("name", new JsonPrimitive("현재 어제와 등록 인원 차이"));
+            yesterdayAndTodayPersonDifferenceField.add("value", new JsonPrimitive("+" + yesterdayAndTodayPersonDifference));
+
+            JsonArray fields = new JsonArray();
+            fields.add(statusField);
+            fields.add(yesterdayPersonField);
+            fields.add(nowPersonField);
+            fields.add(yesterdayAndTodayPersonDifferenceField);
+
+            JsonObject jsonObject = new JsonObject();
+            jsonObject.add("content", new JsonPrimitive(""));
+
+            JsonObject embed = new JsonObject();
+            embed.add("description", new JsonPrimitive("박람회별 등록 인원 로그"));
+            embed.add("color", new JsonPrimitive(16711680));
+            embed.add("fields", fields);
+
+            JsonArray embeds = new JsonArray();
+            embeds.add(embed);
+            jsonObject.add("embeds", embeds);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            RestTemplate restTemplate = new RestTemplate();
+            HttpEntity<String> entity = new HttpEntity<>(jsonObject.toString(), headers);
+            restTemplate.postForObject(discordProperties.getParticipantNumberURL(), entity, String.class);
+        });
+    }
+}

--- a/src/main/java/team/startup/expo/domain/alarm/service/impl/SendParticipantNumberByExpoServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/alarm/service/impl/SendParticipantNumberByExpoServiceImpl.java
@@ -37,13 +37,13 @@ public class SendParticipantNumberByExpoServiceImpl implements SendParticipantNu
             yesterdayPersonField.add("value", new JsonPrimitive(expo.getYesterdayApplicationPerson()));
 
             JsonObject nowPersonField = new JsonObject();
-            nowPersonField.add("name", new JsonPrimitive(LocalDate.now() + " 기준 현재 박람회 등록 인원"));
+            nowPersonField.add("name", new JsonPrimitive(LocalDate.now() + " 박람회 등록 인원"));
             nowPersonField.add("value", new JsonPrimitive(expo.getApplicationPerson()));
 
             String yesterdayAndTodayPersonDifference = String.valueOf(expo.getApplicationPerson() - expo.getYesterdayApplicationPerson());
 
             JsonObject yesterdayAndTodayPersonDifferenceField = new JsonObject();
-            yesterdayAndTodayPersonDifferenceField.add("name", new JsonPrimitive("현재 어제와 등록 인원 차이"));
+            yesterdayAndTodayPersonDifferenceField.add("name", new JsonPrimitive("추가 등록 인원"));
             yesterdayAndTodayPersonDifferenceField.add("value", new JsonPrimitive("+" + yesterdayAndTodayPersonDifference));
 
             JsonArray fields = new JsonArray();

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
@@ -42,6 +42,7 @@ public class FieldApplicationForParticipantServiceImpl implements FieldApplicati
 
 
         saveParticipant(expo, dto);
+        expo.plusApplicationPerson();
 
         try {
             applicationEventPublisher.publishEvent(new SendQrEvent(expoId, dto.getPhoneNumber(), Authority.ROLE_STANDARD));

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationTemporaryQrServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationTemporaryQrServiceImpl.java
@@ -34,6 +34,8 @@ public class FieldApplicationTemporaryQrServiceImpl implements FieldApplicationT
 
         StandardParticipant standardParticipant = saveParticipant(expo, dto);
 
+        expo.plusApplicationPerson();
+
         return ApplicationTemporaryQrResponseDto.builder()
                 .participantId(standardParticipant.getId())
                 .phoneNumber(standardParticipant.getPhoneNumber())

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
@@ -41,6 +41,7 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
             throw new AlreadyApplicationUserException();
 
         saveParticipant(expo, dto);
+        expo.plusApplicationPerson();
 
         try {
             applicationEventPublisher.publishEvent(new SendQrEvent(expoId, dto.getPhoneNumber(), Authority.ROLE_STANDARD));

--- a/src/main/java/team/startup/expo/domain/expo/entity/Expo.java
+++ b/src/main/java/team/startup/expo/domain/expo/entity/Expo.java
@@ -42,4 +42,18 @@ public class Expo {
 
     @Column(nullable = false, columnDefinition = "VARCHAR(15)")
     private String y;
+
+    @Column(nullable = false)
+    private Long applicationPerson;
+
+    @Column(nullable = false)
+    private Long yesterdayApplicationPerson;
+
+    public void saveYesterdayApplicationPerson(Long person) {
+        yesterdayApplicationPerson = person;
+    }
+
+    public void plusApplicationPerson() {
+        applicationPerson++;
+    }
 }

--- a/src/main/java/team/startup/expo/global/thirdparty/discord/properties/DiscordProperties.java
+++ b/src/main/java/team/startup/expo/global/thirdparty/discord/properties/DiscordProperties.java
@@ -9,4 +9,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("discord")
 public class DiscordProperties {
     private final String errorURL;
+    private final String participantNumberURL;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,7 @@ cloud:
 
 discord:
   errorUrl: ${DISCORD_ERROR_URL}
+  participantNumberUrl: ${DISCORD_PARTICIPANT_URL}
 
 management:
   endpoints:


### PR DESCRIPTION
## 💡 배경 및 개요

하루마다 스케줄러를 작동시켜 박람회별 등록자 수 통계를 디스코드로 전송하는 스케줄러를 추가하였습니다

Resolves: 

## 📃 작업내용

* 8시, 12시,16시,20시 마다 박람회 등록자 수 통계를 보내는 스케줄러 추가
* 0시에 총 등록자 수를 어제 등록자 수로 저장하는 스케줄러 추가

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타