### PR TITLE
🔀  :: 박람회 등록 최대 2회로 수정

### DIFF
--- a/src/main/java/team/startup/expo/domain/application/event/handler/SendQrEventHandler.java
+++ b/src/main/java/team/startup/expo/domain/application/event/handler/SendQrEventHandler.java
@@ -26,6 +26,7 @@ import team.startup.expo.domain.sms.exception.NotFoundParticipantException;
 import team.startup.expo.domain.sms.exception.NotFoundTraineeException;
 import team.startup.expo.domain.trainee.entity.Trainee;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
+import team.startup.expo.global.annotation.TransactionService;
 import team.startup.expo.global.exception.ErrorCode;
 import team.startup.expo.global.exception.GlobalException;
 import team.startup.expo.global.sms.SmsProperties;
@@ -41,6 +42,7 @@ import java.util.concurrent.CompletableFuture;
 @Component
 @RequiredArgsConstructor
 @Slf4j
+@TransactionService
 public class SendQrEventHandler {
 
     private final static int WIDTH = 200;
@@ -70,6 +72,10 @@ public class SendQrEventHandler {
                 byte[] qrBytes = createQr(information);
 
                 Message message = createMessage(qrBytes, sendQrEvent);
+
+                participant.plusSmsTryTime();
+
+                standardParticipantRepository.save(participant);
 
                 response = messageService.sendOne(new SingleMessageSendingRequest(message));
             } else if (sendQrEvent.getAuthority() == Authority.ROLE_TRAINEE) {

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
@@ -37,11 +37,16 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
         if (!dateUtil.dateComparison(expo.getStartedDay(), expo.getFinishedDay()))
             throw new NotInProgressExpoException();
 
-        if (standardParticipantRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo) || traineeRepository.existsByPhoneNumberAndExpo(dto.getPhoneNumber(), expo))
-            throw new AlreadyApplicationUserException();
+        StandardParticipant standardParticipant = standardParticipantRepository.findByPhoneNumberAndExpoForNullCheck(dto.getPhoneNumber(), expo);
 
-        saveParticipant(expo, dto);
-        expo.plusApplicationPerson();
+        if (standardParticipant != null) {
+            if (standardParticipant.getSmsTryTime() >= 2) {
+                throw new AlreadyApplicationUserException();
+            }
+        } else {
+            saveParticipant(expo, dto);
+            expo.plusApplicationPerson();
+        }
 
         try {
             applicationEventPublisher.publishEvent(new SendQrEvent(expoId, dto.getPhoneNumber(), Authority.ROLE_STANDARD));

--- a/src/main/java/team/startup/expo/domain/participant/entity/StandardParticipant.java
+++ b/src/main/java/team/startup/expo/domain/participant/entity/StandardParticipant.java
@@ -47,4 +47,11 @@ public class StandardParticipant {
     @JoinColumn(name = "expo_id")
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Expo expo;
+
+    @Column(nullable = false)
+    private Integer smsTryTime;
+
+    public void plusSmsTryTime() {
+        smsTryTime++;
+    }
 }

--- a/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantRepository.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantRepository.java
@@ -15,17 +15,12 @@ public interface StandardParticipantRepository extends JpaRepository<StandardPar
 
     Optional<StandardParticipant> findByPhoneNumberAndExpo(String phoneNumber, Expo expo);
 
-    void deleteByExpo(Expo expo);
-
     @Query("SELECT sp FROM StandardParticipant sp " +
-            "JOIN sp.expo e " +
-            "WHERE e = :expo " +
-            "AND sp.applicationType = :applicationType " +
-            "AND sp.name LIKE %:name%")
-    List<StandardParticipant> findByExpoAndApplicationTypeAndName(Expo expo, ApplicationType applicationType, String name);
+            "WHERE sp.phoneNumber = :phoneNumber " +
+            "AND sp.expo=:expo")
+    StandardParticipant findByPhoneNumberAndExpoForNullCheck(String phoneNumber, Expo expo);
 
-    List<StandardParticipant> findByExpoAndApplicationType(Expo expo, ApplicationType applicationType);
-
+    void deleteByExpo(Expo expo);
 
     Boolean existsByPhoneNumberAndExpo(String phoneNumber, Expo expo);
 


### PR DESCRIPTION
## 💡 배경 및 개요

등록시 SMS 한번만 발송되지만 만약 문자를 받지 못한 것을 대비해 최대 2번 발송되도록 하였습니다.

Resolves: #{이슈번호}

## 📃 작업내용

* smsTryTime 컬럼 추가
* findByPhoneNumberAndExpoForNullCheck JPQL 쿼리 추가

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타