### PR TITLE
박람회 참가 qr 입장 서비스 클래스 데드락 개선

### DIFF
--- a/src/main/java/team/startup/expo/domain/attendance/service/impl/PreEnterScanQrCodeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/attendance/service/impl/PreEnterScanQrCodeServiceImpl.java
@@ -2,6 +2,7 @@ package team.startup.expo.domain.attendance.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import team.startup.expo.domain.admin.entity.Authority;
 import team.startup.expo.domain.attendance.event.EnterSmsEvent;
 import team.startup.expo.domain.attendance.exception.AlreadyEnterExpoUserException;
@@ -28,7 +29,6 @@ import team.startup.expo.global.date.DateUtil;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 @TransactionService
 @RequiredArgsConstructor
@@ -63,23 +63,20 @@ public class PreEnterScanQrCodeServiceImpl implements PreEnterScanQrCodeService 
         StandardParticipant standardParticipant = standardParticipantRepository.findByPhoneNumberAndExpo(dto.getPhoneNumber(), expo)
                 .orElseThrow(NotFoundParticipantException::new);
 
-        Optional<StandardParticipantParticipation> standardParticipantParticipation =
-                standardParticipantParticipationRepository.findByExpoAndStandardParticipantAndAttendanceDateForWrite(expo, standardParticipant, LocalDate.now());
-
-        if (standardParticipantParticipation.isEmpty()) {
-            StandardParticipantParticipation newStandardParticipantParticipation = StandardParticipantParticipation.builder()
+        try {
+            standardParticipantParticipationRepository.save(StandardParticipantParticipation.builder()
                     .entryTime(LocalDateTime.now())
                     .attendanceDate(LocalDate.now())
                     .standardParticipant(standardParticipant)
                     .expo(expo)
-                    .build();
+                    .build());
 
-            standardParticipantParticipationRepository.save(newStandardParticipantParticipation);
-
-            applicationEventPublisher.publishEvent(new EnterSmsEvent(expo.getId(), standardParticipant.getPhoneNumber(), Authority.ROLE_STANDARD));
-        } else {
+            standardParticipantParticipationRepository.flush();
+        } catch (DataIntegrityViolationException e) {
             throw new AlreadyEnterExpoUserException();
         }
+
+        applicationEventPublisher.publishEvent(new EnterSmsEvent(expo.getId(), standardParticipant.getPhoneNumber(), Authority.ROLE_STANDARD));
 
         return PreEnterScanQrCodeResponseDto.builder()
                 .id(standardParticipant.getId())
@@ -94,21 +91,16 @@ public class PreEnterScanQrCodeServiceImpl implements PreEnterScanQrCodeService 
         Trainee trainee = traineeRepository.findByPhoneNumberAndExpo(dto.getPhoneNumber(), expo)
                 .orElseThrow(NotFoundTraineeException::new);
 
-        Optional<TraineeParticipation> traineeParticipation =
-                traineeParticipationRepository.findByExpoAndTraineeAndAttendanceDateForWrite(expo, trainee, LocalDate.now());
-
-        if (traineeParticipation.isEmpty()) {
-            TraineeParticipation newTraineeParticipation = TraineeParticipation.builder()
+        try {
+            traineeParticipationRepository.save(TraineeParticipation.builder()
                     .entryTime(LocalDateTime.now())
                     .attendanceDate(LocalDate.now())
                     .trainee(trainee)
                     .expo(expo)
-                    .build();
+                    .build());
 
-            traineeParticipationRepository.save(newTraineeParticipation);
-
-            applicationEventPublisher.publishEvent(new EnterSmsEvent(expo.getId(), trainee.getPhoneNumber(), Authority.ROLE_TRAINEE));
-        } else {
+            traineeParticipationRepository.flush();
+        } catch (DataIntegrityViolationException e) {
             throw new AlreadyEnterExpoUserException();
         }
 

--- a/src/main/java/team/startup/expo/domain/participant/entity/StandardParticipantParticipation.java
+++ b/src/main/java/team/startup/expo/domain/participant/entity/StandardParticipantParticipation.java
@@ -17,7 +17,10 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @Getter
-@Table(name = "tb_standard_participant_participation")
+@Table(
+        name = "tb_standard_participant_participation",
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"expo_id", "standard_participant_id", "attendance_date"})}
+)
 public class StandardParticipantParticipation {
 
     @Id

--- a/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantParticipationRepository.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/StandardParticipantParticipationRepository.java
@@ -1,22 +1,7 @@
 package team.startup.expo.domain.participant.repository;
 
-import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
-import team.startup.expo.domain.expo.entity.Expo;
-import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.participant.entity.StandardParticipantParticipation;
 
-import java.time.LocalDate;
-import java.util.Optional;
-
 public interface StandardParticipantParticipationRepository extends JpaRepository<StandardParticipantParticipation, Long> {
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT spp FROM StandardParticipantParticipation spp " +
-            "WHERE spp.expo=:expo " +
-            "AND spp.standardParticipant=:standardParticipant " +
-            "AND spp.attendanceDate=:attendanceDate")
-    Optional<StandardParticipantParticipation> findByExpoAndStandardParticipantAndAttendanceDateForWrite(Expo expo, StandardParticipant standardParticipant, LocalDate attendanceDate);
 }

--- a/src/main/java/team/startup/expo/domain/trainee/entity/TraineeParticipation.java
+++ b/src/main/java/team/startup/expo/domain/trainee/entity/TraineeParticipation.java
@@ -17,7 +17,10 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @Getter
-@Table(name = "tb_trainee_participation")
+@Table(
+        name = "tb_trainee_participation",
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"expo_id", "trainee_id", "attendance_date"})}
+)
 public class TraineeParticipation {
 
     @Id

--- a/src/main/java/team/startup/expo/domain/trainee/repository/TraineeParticipationRepository.java
+++ b/src/main/java/team/startup/expo/domain/trainee/repository/TraineeParticipationRepository.java
@@ -1,22 +1,7 @@
 package team.startup.expo.domain.trainee.repository;
 
-import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
-import team.startup.expo.domain.expo.entity.Expo;
-import team.startup.expo.domain.trainee.entity.Trainee;
 import team.startup.expo.domain.trainee.entity.TraineeParticipation;
 
-import java.time.LocalDate;
-import java.util.Optional;
-
 public interface TraineeParticipationRepository extends JpaRepository<TraineeParticipation, Long> {
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT tp " +
-            "FROM TraineeParticipation tp " +
-            "WHERE tp.expo=:expo " +
-            "AND tp.trainee=:trainee AND tp.attendanceDate=:attendanceDate")
-    Optional<TraineeParticipation> findByExpoAndTraineeAndAttendanceDateForWrite(Expo expo, Trainee trainee, LocalDate attendanceDate);
 }


### PR DESCRIPTION
## 💡 배경 및 개요

> 박람회 참가 qr 입장 서비스 클래스의 데드락을 개선하였습니다.
> 기존에는 비관적 락을 이용하여 동시성 문제를 제어하였지만 입장 요청의 동시에 들어올 경우 락 경합으로 인해 데드락이 발생했습니다.
> 이를 유니크 제약조건과 try - catch문 기반의 예외 처리 방식으로 개선하여 락 경쟁을 없애고 트랜잭션 충돌 없이 동시 입장 처리를 안정적으로 처리할 수 있도록 개선하였습니다.
> 테스트 코드를 통해 단건 요청과 50건 동시 요청 모두 정상적으로 처리되는것을 확인하였습니다.

Resolves: #311

## 📃 작업내용

> PreEnterScanQrCodeService의 입장 로그 조회 로직 제거 및 insert 이후 try - catch문 기반의 예외 처리 방식으로 수정
> TraineeParticipation과 StandardParticipantParticipation 엔티티에 유니크 제약 조건 추가

## 🙋‍♂️ 리뷰노트

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타