### PR TITLE
JSON 필드 MongoDB로 마이그레이션

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+	implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	compileOnly("org.projectlombok:lombok")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,52 @@ services:
     networks:
       - monitoring-network
 
+  mysql:
+    image: mysql:latest
+    container_name: expo-mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: expo
+      MYSQL_USER: expo
+      MYSQL_PASSWORD: expo1234
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - monitoring-network
+
+  redis:
+    image: redis:latest
+    container_name: expo-redis
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - monitoring-network
+
+  mongodb:
+    image: mongo:latest
+    container_name: expo-mongodb
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: root
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+    networks:
+      - monitoring-network
+
 networks:
   monitoring-network:
     driver: bridge
+
+volumes:
+  mysql_data:
+  redis_data:
+  mongodb_data:

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
@@ -1,4 +1,10 @@
 package team.startup.expo.domain.application.service.impl;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import team.startup.expo.domain.mongo.entity.DynamicJsonData;
+import team.startup.expo.domain.mongo.entity.OwnerType;
+import team.startup.expo.domain.mongo.repository.DynamicJsonDataRepository;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -14,7 +20,6 @@ import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.application.event.SendQrEvent;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
-import team.startup.expo.domain.trainee.repository.TraineeRepository;
 import team.startup.expo.global.annotation.TransactionService;
 import team.startup.expo.global.date.DateUtil;
 import team.startup.expo.global.exception.ErrorCode;
@@ -28,6 +33,8 @@ public class FieldApplicationForParticipantServiceImpl implements FieldApplicati
     private final StandardParticipantRepository standardParticipantRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final DateUtil dateUtil;
+    private final DynamicJsonDataRepository dynamicJsonDataRepository;
+    private final ObjectMapper objectMapper;
 
     public void execute(String expoId, ApplicationForParticipantRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
@@ -61,7 +68,6 @@ public class FieldApplicationForParticipantServiceImpl implements FieldApplicati
                         .name(dto.getName())
                         .phoneNumber(dto.getPhoneNumber())
                         .authority(Authority.ROLE_STANDARD)
-                        .informationJson(dto.getInformationJson())
                         .applicationType(ApplicationType.FIELD)
                         .personalInformationStatus(dto.getPersonalInformationStatus())
                         .smsTryTime(0)
@@ -69,5 +75,22 @@ public class FieldApplicationForParticipantServiceImpl implements FieldApplicati
                         .build());
 
         standardParticipantRepository.save(standardParticipant);
+        Map<String, Object> answers = parseJson(dto.getInformationJson());
+        DynamicJsonData doc = new DynamicJsonData(
+                null,
+                OwnerType.STANDARD_PARTICIPANT,
+                standardParticipant.getId(),
+                answers
+        );
+        dynamicJsonDataRepository.save(doc);
+    }
+
+    private Map<String, Object> parseJson(String raw) {
+        try {
+            if (raw == null || raw.isBlank()) return null;
+            return objectMapper.readValue(raw, new TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
@@ -1,5 +1,4 @@
 package team.startup.expo.domain.application.service.impl;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import team.startup.expo.domain.mongo.entity.DynamicJsonData;
@@ -75,7 +74,7 @@ public class FieldApplicationForParticipantServiceImpl implements FieldApplicati
                         .build());
 
         standardParticipantRepository.save(standardParticipant);
-        Map<String, Object> answers = parseJson(dto.getInformationJson());
+        String answers = dto.getInformationJson();
         DynamicJsonData doc = new DynamicJsonData(
                 null,
                 OwnerType.STANDARD_PARTICIPANT,
@@ -83,14 +82,5 @@ public class FieldApplicationForParticipantServiceImpl implements FieldApplicati
                 answers
         );
         dynamicJsonDataRepository.save(doc);
-    }
-
-    private Map<String, Object> parseJson(String raw) {
-        try {
-            if (raw == null || raw.isBlank()) return null;
-            return objectMapper.readValue(raw, new TypeReference<Map<String, Object>>() {});
-        } catch (Exception e) {
-            return null;
-        }
     }
 }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForTraineeServiceImpl.java
@@ -1,5 +1,7 @@
 package team.startup.expo.domain.application.service.impl;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import team.startup.expo.domain.admin.entity.Authority;
@@ -12,6 +14,9 @@ import team.startup.expo.domain.application.presentation.dto.request.Application
 import team.startup.expo.domain.application.service.FieldApplicationForTraineeService;
 import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.application.event.SendQrEvent;
+import team.startup.expo.domain.mongo.entity.DynamicJsonData;
+import team.startup.expo.domain.mongo.entity.OwnerType;
+import team.startup.expo.domain.mongo.repository.DynamicJsonDataRepository;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.domain.trainee.entity.Trainee;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
@@ -19,6 +24,8 @@ import team.startup.expo.global.annotation.TransactionService;
 import team.startup.expo.global.date.DateUtil;
 import team.startup.expo.global.exception.ErrorCode;
 import team.startup.expo.global.exception.GlobalException;
+
+import java.util.Map;
 
 @TransactionService
 @RequiredArgsConstructor
@@ -29,6 +36,8 @@ public class FieldApplicationForTraineeServiceImpl implements FieldApplicationFo
     private final StandardParticipantRepository standardParticipantRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final DateUtil dateUtil;
+    private final DynamicJsonDataRepository dynamicJsonDataRepository;
+    private final ObjectMapper objectMapper;
 
     public void execute(String expoId, ApplicationForTraineeRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
@@ -57,11 +66,28 @@ public class FieldApplicationForTraineeServiceImpl implements FieldApplicationFo
                         .authority(Authority.ROLE_TRAINEE)
                         .name(dto.getName())
                         .applicationType(ApplicationType.PRE)
-                        .informationJson(dto.getInformationJson())
                         .personalInformationStatus(dto.getPersonalInformationStatus())
                         .expo(expo)
                         .build());
 
         traineeRepository.save(trainee);
+
+        Map<String, Object> answers = parseJson(dto.getInformationJson());
+        DynamicJsonData doc = new DynamicJsonData(
+                null,
+                OwnerType.TRAINEE,
+                trainee.getId(),
+                answers
+        );
+        dynamicJsonDataRepository.save(doc);
+    }
+
+    private Map<String, Object> parseJson(String raw) {
+        try {
+            if (raw == null || raw.isBlank()) return null;
+            return objectMapper.readValue(raw, new TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForTraineeServiceImpl.java
@@ -72,22 +72,12 @@ public class FieldApplicationForTraineeServiceImpl implements FieldApplicationFo
 
         traineeRepository.save(trainee);
 
-        Map<String, Object> answers = parseJson(dto.getInformationJson());
         DynamicJsonData doc = new DynamicJsonData(
                 null,
                 OwnerType.TRAINEE,
                 trainee.getId(),
-                answers
+                dto.getInformationJson()
         );
         dynamicJsonDataRepository.save(doc);
-    }
-
-    private Map<String, Object> parseJson(String raw) {
-        try {
-            if (raw == null || raw.isBlank()) return null;
-            return objectMapper.readValue(raw, new TypeReference<Map<String, Object>>() {});
-        } catch (Exception e) {
-            return null;
-        }
     }
 }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationTemporaryQrServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationTemporaryQrServiceImpl.java
@@ -1,5 +1,7 @@
 package team.startup.expo.domain.application.service.impl;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import team.startup.expo.domain.admin.entity.Authority;
 import team.startup.expo.domain.application.presentation.dto.request.ApplicationTemporaryQrRequestDto;
@@ -9,12 +11,16 @@ import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.exception.NotInProgressExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.mongo.entity.DynamicJsonData;
+import team.startup.expo.domain.mongo.entity.OwnerType;
+import team.startup.expo.domain.mongo.repository.DynamicJsonDataRepository;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.global.annotation.TransactionService;
 import team.startup.expo.global.date.DateUtil;
 
+import java.util.Map;
 import java.util.UUID;
 
 @TransactionService
@@ -24,6 +30,8 @@ public class FieldApplicationTemporaryQrServiceImpl implements FieldApplicationT
     private final ExpoRepository expoRepository;
     private final StandardParticipantRepository standardParticipantRepository;
     private final DateUtil dateUtil;
+    private final DynamicJsonDataRepository dynamicJsonDataRepository;
+    private final ObjectMapper objectMapper;
 
     public ApplicationTemporaryQrResponseDto execute(String expoId, ApplicationTemporaryQrRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
@@ -53,19 +61,38 @@ public class FieldApplicationTemporaryQrServiceImpl implements FieldApplicationT
                 .name(dto.getName())
                 .phoneNumber(phoneNumber)
                 .authority(Authority.ROLE_STANDARD)
-                .informationJson(dto.getInformationJson())
                 .applicationType(ApplicationType.FIELD)
                 .personalInformationStatus(dto.getPersonalInformationStatus())
                 .smsTryTime(0)
                 .expo(expo)
                 .build();
 
-        return standardParticipantRepository.save(standardParticipant);
+        standardParticipantRepository.save(standardParticipant);
+
+        Map<String, Object> answers = parseJson(dto.getInformationJson());
+        DynamicJsonData doc = new DynamicJsonData(
+                null,
+                OwnerType.STANDARD_PARTICIPANT,
+                standardParticipant.getId(),
+                answers
+        );
+        dynamicJsonDataRepository.save(doc);
+
+        return standardParticipant;
     }
 
     public String generateUniquePhoneNumber() {
         String temporaryPhoneNumber = UUID.randomUUID().toString().replaceAll("[^0-9]", "").substring(0, 8);
         return "000" + temporaryPhoneNumber.substring(0, 4) + temporaryPhoneNumber.substring(4);
+    }
+
+    private Map<String, Object> parseJson(String raw) {
+        try {
+            if (raw == null || raw.isBlank()) return null;
+            return objectMapper.readValue(raw, new TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            return null;
+        }
     }
 
 }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationTemporaryQrServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationTemporaryQrServiceImpl.java
@@ -1,6 +1,5 @@
 package team.startup.expo.domain.application.service.impl;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import team.startup.expo.domain.admin.entity.Authority;
@@ -20,7 +19,6 @@ import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.global.annotation.TransactionService;
 import team.startup.expo.global.date.DateUtil;
 
-import java.util.Map;
 import java.util.UUID;
 
 @TransactionService
@@ -69,7 +67,7 @@ public class FieldApplicationTemporaryQrServiceImpl implements FieldApplicationT
 
         standardParticipantRepository.save(standardParticipant);
 
-        Map<String, Object> answers = parseJson(dto.getInformationJson());
+        String answers = dto.getInformationJson();
         DynamicJsonData doc = new DynamicJsonData(
                 null,
                 OwnerType.STANDARD_PARTICIPANT,
@@ -84,15 +82,6 @@ public class FieldApplicationTemporaryQrServiceImpl implements FieldApplicationT
     public String generateUniquePhoneNumber() {
         String temporaryPhoneNumber = UUID.randomUUID().toString().replaceAll("[^0-9]", "").substring(0, 8);
         return "000" + temporaryPhoneNumber.substring(0, 4) + temporaryPhoneNumber.substring(4);
-    }
-
-    private Map<String, Object> parseJson(String raw) {
-        try {
-            if (raw == null || raw.isBlank()) return null;
-            return objectMapper.readValue(raw, new TypeReference<Map<String, Object>>() {});
-        } catch (Exception e) {
-            return null;
-        }
     }
 
 }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
@@ -78,22 +78,13 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
 
         standardParticipantRepository.save(standardParticipant);
 
-        Map<String, Object> answers = parseJson(dto.getInformationJson());
         DynamicJsonData doc = new DynamicJsonData(
                 null,
                 OwnerType.STANDARD_PARTICIPANT,
                 standardParticipant.getId(),
-                answers
+                dto.getInformationJson()
         );
         dynamicJsonDataRepository.save(doc);
     }
 
-    private Map<String, Object> parseJson(String raw) {
-        try {
-            if (raw == null || raw.isBlank()) return null;
-            return objectMapper.readValue(raw, new TypeReference<Map<String, Object>>() {});
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
@@ -1,5 +1,7 @@
 package team.startup.expo.domain.application.service.impl;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import team.startup.expo.domain.admin.entity.Authority;
@@ -13,12 +15,17 @@ import team.startup.expo.domain.application.service.PreApplicationForParticipant
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.application.event.SendQrEvent;
+import team.startup.expo.domain.mongo.entity.DynamicJsonData;
+import team.startup.expo.domain.mongo.entity.OwnerType;
+import team.startup.expo.domain.mongo.repository.DynamicJsonDataRepository;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
 import team.startup.expo.global.annotation.TransactionService;
 import team.startup.expo.global.date.DateUtil;
 import team.startup.expo.global.exception.ErrorCode;
 import team.startup.expo.global.exception.GlobalException;
+
+import java.util.Map;
 
 @TransactionService
 @RequiredArgsConstructor
@@ -29,6 +36,8 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
     private final TraineeRepository traineeRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final DateUtil dateUtil;
+    private final DynamicJsonDataRepository dynamicJsonDataRepository;
+    private final ObjectMapper objectMapper;
 
     public void execute(String expoId, ApplicationForParticipantRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
@@ -61,7 +70,6 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
                         .name(dto.getName())
                         .phoneNumber(dto.getPhoneNumber())
                         .authority(Authority.ROLE_STANDARD)
-                        .informationJson(dto.getInformationJson())
                         .applicationType(ApplicationType.PRE)
                         .personalInformationStatus(dto.getPersonalInformationStatus())
                         .expo(expo)
@@ -69,5 +77,23 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
                         .build());
 
         standardParticipantRepository.save(standardParticipant);
+
+        Map<String, Object> answers = parseJson(dto.getInformationJson());
+        DynamicJsonData doc = new DynamicJsonData(
+                null,
+                OwnerType.STANDARD_PARTICIPANT,
+                standardParticipant.getId(),
+                answers
+        );
+        dynamicJsonDataRepository.save(doc);
+    }
+
+    private Map<String, Object> parseJson(String raw) {
+        try {
+            if (raw == null || raw.isBlank()) return null;
+            return objectMapper.readValue(raw, new TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
@@ -72,22 +72,12 @@ public class PreApplicationForTraineeServiceImpl implements PreApplicationForTra
 
         traineeRepository.save(trainee);
 
-        Map<String, Object> answers = parseJson(dto.getInformationJson());
         DynamicJsonData doc = new DynamicJsonData(
                 null,
                 OwnerType.TRAINEE,
                 trainee.getId(),
-                answers
+                dto.getInformationJson()
         );
         dynamicJsonDataRepository.save(doc);
-    }
-
-    private Map<String, Object> parseJson(String raw) {
-        try {
-            if (raw == null || raw.isBlank()) return null;
-            return objectMapper.readValue(raw, new TypeReference<Map<String, Object>>() {});
-        } catch (Exception e) {
-            return null;
-        }
     }
 }

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
@@ -1,5 +1,7 @@
 package team.startup.expo.domain.application.service.impl;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import team.startup.expo.domain.admin.entity.Authority;
@@ -12,6 +14,9 @@ import team.startup.expo.domain.application.presentation.dto.request.Application
 import team.startup.expo.domain.application.service.PreApplicationForTraineeService;
 import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.application.event.SendQrEvent;
+import team.startup.expo.domain.mongo.entity.DynamicJsonData;
+import team.startup.expo.domain.mongo.entity.OwnerType;
+import team.startup.expo.domain.mongo.repository.DynamicJsonDataRepository;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.domain.trainee.entity.Trainee;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
@@ -19,6 +24,8 @@ import team.startup.expo.global.annotation.TransactionService;
 import team.startup.expo.global.date.DateUtil;
 import team.startup.expo.global.exception.ErrorCode;
 import team.startup.expo.global.exception.GlobalException;
+
+import java.util.Map;
 
 @TransactionService
 @RequiredArgsConstructor
@@ -29,6 +36,8 @@ public class PreApplicationForTraineeServiceImpl implements PreApplicationForTra
     private final StandardParticipantRepository standardParticipantRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final DateUtil dateUtil;
+    private final DynamicJsonDataRepository dynamicJsonDataRepository;
+    private final ObjectMapper objectMapper;
 
     public void execute(String expoId, ApplicationForTraineeRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
@@ -57,11 +66,28 @@ public class PreApplicationForTraineeServiceImpl implements PreApplicationForTra
                         .authority(Authority.ROLE_TRAINEE)
                         .name(dto.getName())
                         .applicationType(ApplicationType.PRE)
-                        .informationJson(dto.getInformationJson())
                         .personalInformationStatus(dto.getPersonalInformationStatus())
                         .expo(expo)
                         .build());
 
         traineeRepository.save(trainee);
+
+        Map<String, Object> answers = parseJson(dto.getInformationJson());
+        DynamicJsonData doc = new DynamicJsonData(
+                null,
+                OwnerType.TRAINEE,
+                trainee.getId(),
+                answers
+        );
+        dynamicJsonDataRepository.save(doc);
+    }
+
+    private Map<String, Object> parseJson(String raw) {
+        try {
+            if (raw == null || raw.isBlank()) return null;
+            return objectMapper.readValue(raw, new TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/team/startup/expo/domain/attendance/service/impl/ScanStandardProByQrCodeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/attendance/service/impl/ScanStandardProByQrCodeServiceImpl.java
@@ -2,7 +2,6 @@ package team.startup.expo.domain.attendance.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import team.startup.expo.domain.attendance.exception.NotFoundStandardProgramException;
-import team.startup.expo.domain.attendance.exception.NotFoundStandardProgramUserException;
 import team.startup.expo.domain.attendance.presentation.dto.request.ScanStandardProRequestDto;
 import team.startup.expo.domain.attendance.service.ScanStandardProByQrCodeService;
 import team.startup.expo.domain.expo.exception.NotInProgressExpoException;

--- a/src/main/java/team/startup/expo/domain/excel/service/impl/ProgramParticipantInfoToExcelServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/excel/service/impl/ProgramParticipantInfoToExcelServiceImpl.java
@@ -1,11 +1,8 @@
 package team.startup.expo.domain.excel.service.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFColor;
@@ -13,6 +10,9 @@ import org.apache.poi.xssf.usermodel.XSSFFont;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import team.startup.expo.domain.attendance.exception.NotFoundStandardProgramException;
 import team.startup.expo.domain.excel.service.ProgramParticipantInfoToExcelService;
+import team.startup.expo.domain.mongo.entity.DynamicJsonData;
+import team.startup.expo.domain.mongo.entity.OwnerType;
+import team.startup.expo.domain.mongo.repository.DynamicJsonDataRepository;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.standard.entity.StandardProgram;
 import team.startup.expo.domain.standard.entity.StandardProgramUser;
@@ -26,20 +26,20 @@ import java.util.*;
 @RequiredArgsConstructor
 public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticipantInfoToExcelService {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
     private final StandardProgramUserRepository standardProgramUserRepository;
     private final StandardProgramRepository standardProgramRepository;
+    private final DynamicJsonDataRepository dynamicJsonDataRepository;
 
-    public void execute(String expoId, Long programId, HttpServletResponse res) throws JsonProcessingException {
-        try {
+    public void execute(String expoId, Long programId, HttpServletResponse res) {
+        try (Workbook workbook = new XSSFWorkbook()) {
             StandardProgram standardProgram = standardProgramRepository.findByIdAndExpoId(programId, expoId)
                     .orElseThrow(NotFoundStandardProgramException::new);
 
             List<StandardProgramUser> standardProgramUsers = standardProgramUserRepository.findByStandardProgram(standardProgram);
+            List<StandardParticipant> standardParticipants = standardProgramUsers.stream()
+                    .map(StandardProgramUser::getStandardParticipant)
+                    .toList();
 
-            List<StandardParticipant> standardParticipants = standardProgramUsers.stream().map(StandardProgramUser::getStandardParticipant).toList();
-
-            Workbook workbook = new XSSFWorkbook();
             Sheet sheet = workbook.createSheet("프로그램 참가자 정보");
             sheet.setDefaultColumnWidth(20);
 
@@ -63,19 +63,27 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
             bodyStyle.setBorderLeft(BorderStyle.THIN);
             bodyStyle.setBorderRight(BorderStyle.THIN);
 
-            // 헤더 설정
+            // 헤더 설정 (기본)
             List<String> headers = new ArrayList<>(List.of("순위", "이름", "전화번호", "개인정보 동의 여부"));
 
-            String infoHeaderJson = standardParticipants.get(0).getInformationJson();
-            String unescapedInfoHeaderJson = StringEscapeUtils.unescapeJson(infoHeaderJson);
-            Map<String, String> infoHeaderJsonMap = objectMapper.readValue(unescapedInfoHeaderJson, Map.class);
-            Set<String> infoDynamicKeys = new LinkedHashSet<>(infoHeaderJsonMap.keySet());
+            // 동적 헤더 키 수집 (Mongo answers 기준)
+            Set<String> infoDynamicKeys = new LinkedHashSet<>();
+            if (!standardParticipants.isEmpty()) {
+                StandardParticipant first = standardParticipants.get(0);
+                DynamicJsonData firstInfo = dynamicJsonDataRepository
+                        .findByOwnerTypeAndOwnerId(OwnerType.STANDARD_PARTICIPANT, first.getId())
+                        .orElse(null);
+                if (firstInfo != null && firstInfo.getAnswers() != null) {
+                    infoDynamicKeys.addAll(firstInfo.getAnswers().keySet());
+                }
+            }
 
             headers.addAll(infoDynamicKeys);
 
             List<String> additionHeader = new ArrayList<>(List.of("학번", "서명", "비고"));
             headers.addAll(additionHeader);
 
+            // 헤더 행 생성
             Row headerRow = sheet.createRow(0);
             for (int i = 0; i < headers.size(); i++) {
                 Cell cell = headerRow.createCell(i);
@@ -83,38 +91,55 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
                 cell.setCellStyle(headerStyle);
             }
 
+            // 데이터 행
             int rowCount = 1;
+            int rank = 1;
             for (StandardParticipant participant : standardParticipants) {
                 Row row = sheet.createRow(rowCount++);
 
-                int cellIndex = 1;
-
-                // 기본 정보
+                int cellIndex = 0;
+                row.createCell(cellIndex++).setCellValue(rank++); // 순위
                 row.createCell(cellIndex++).setCellValue(participant.getName());
                 row.createCell(cellIndex++).setCellValue(participant.getPhoneNumber());
-                row.createCell(cellIndex++).setCellValue(participant.getPersonalInformationStatus() ? "동의" : "미동의");
+                row.createCell(cellIndex++).setCellValue(Boolean.TRUE.equals(participant.getPersonalInformationStatus()) ? "동의" : "미동의");
 
-                String escapedInfoJson = participant.getInformationJson();
-                String unescapedInfoJson = StringEscapeUtils.unescapeJson(escapedInfoJson);
-                Map<String, String> infoJsonMap = objectMapper.readValue(unescapedInfoJson, Map.class);
+                // Mongo에서 동적 값 로드
+                Map<String, String> infoJsonMap = new HashMap<>();
+                DynamicJsonData infoDoc = dynamicJsonDataRepository
+                        .findByOwnerTypeAndOwnerId(OwnerType.STANDARD_PARTICIPANT, participant.getId())
+                        .orElse(null);
+                if (infoDoc != null && infoDoc.getAnswers() != null) {
+                    for (Map.Entry<String, Object> entry : infoDoc.getAnswers().entrySet()) {
+                        infoJsonMap.put(entry.getKey(), entry.getValue() != null ? String.valueOf(entry.getValue()) : "");
+                    }
+                }
 
+                // 동적 키 값 채우기
                 for (String key : infoDynamicKeys) {
-                    row.createCell(cellIndex++).setCellValue(infoJsonMap.getOrDefault(key, ""));
+                    Cell c = row.createCell(cellIndex++);
+                    c.setCellValue(infoJsonMap.getOrDefault(key, ""));
+                    c.setCellStyle(bodyStyle);
+                }
+
+                // 추가 컬럼 (학번, 서명, 비고) - 비워두기
+                for (int i = 0; i < 3; i++) {
+                    Cell c = row.createCell(cellIndex++);
+                    c.setCellValue("");
+                    c.setCellStyle(bodyStyle);
                 }
             }
 
-            // 파일명 설정
+            // 파일명/헤더
             String fileName = "Program_Participant_Information";
-
             res.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
             res.setHeader("Content-Disposition", "attachment; filename=" + fileName + ".xlsx");
 
-            ServletOutputStream outputStream = res.getOutputStream();
-            workbook.write(outputStream);
-            workbook.close();
+            try (ServletOutputStream outputStream = res.getOutputStream()) {
+                workbook.write(outputStream);
+                outputStream.flush();
+            }
         } catch (Exception e) {
-            throw new RuntimeException("엑셀 파일 생성 중 오류 발생: " + e.getMessage(), e);
+            throw new RuntimeException("엑셀 파일 생성 중 오류 발생", e);
         }
-
     }
 }

--- a/src/main/java/team/startup/expo/domain/excel/service/impl/ProgramParticipantInfoToExcelServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/excel/service/impl/ProgramParticipantInfoToExcelServiceImpl.java
@@ -43,7 +43,6 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
             Sheet sheet = workbook.createSheet("프로그램 참가자 정보");
             sheet.setDefaultColumnWidth(20);
 
-            // 스타일 설정
             XSSFFont headerFont = (XSSFFont) workbook.createFont();
             headerFont.setBold(true);
             headerFont.setColor(new XSSFColor(new byte[]{(byte) 255, (byte) 255, (byte) 255}));
@@ -63,10 +62,8 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
             bodyStyle.setBorderLeft(BorderStyle.THIN);
             bodyStyle.setBorderRight(BorderStyle.THIN);
 
-            // 헤더 설정 (기본)
             List<String> headers = new ArrayList<>(List.of("순위", "이름", "전화번호", "개인정보 동의 여부"));
 
-            // 동적 헤더 키 수집 (Mongo answers 기준)
             Set<String> infoDynamicKeys = new LinkedHashSet<>();
             if (!standardParticipants.isEmpty()) {
                 StandardParticipant first = standardParticipants.get(0);
@@ -83,7 +80,6 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
             List<String> additionHeader = new ArrayList<>(List.of("학번", "서명", "비고"));
             headers.addAll(additionHeader);
 
-            // 헤더 행 생성
             Row headerRow = sheet.createRow(0);
             for (int i = 0; i < headers.size(); i++) {
                 Cell cell = headerRow.createCell(i);
@@ -91,7 +87,6 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
                 cell.setCellStyle(headerStyle);
             }
 
-            // 데이터 행
             int rowCount = 1;
             int rank = 1;
             for (StandardParticipant participant : standardParticipants) {
@@ -103,7 +98,6 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
                 row.createCell(cellIndex++).setCellValue(participant.getPhoneNumber());
                 row.createCell(cellIndex++).setCellValue(Boolean.TRUE.equals(participant.getPersonalInformationStatus()) ? "동의" : "미동의");
 
-                // Mongo에서 동적 값 로드
                 Map<String, String> infoJsonMap = new HashMap<>();
                 DynamicJsonData infoDoc = dynamicJsonDataRepository
                         .findByOwnerTypeAndOwnerId(OwnerType.STANDARD_PARTICIPANT, participant.getId())
@@ -114,14 +108,12 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
                     }
                 }
 
-                // 동적 키 값 채우기
                 for (String key : infoDynamicKeys) {
                     Cell c = row.createCell(cellIndex++);
                     c.setCellValue(infoJsonMap.getOrDefault(key, ""));
                     c.setCellStyle(bodyStyle);
                 }
 
-                // 추가 컬럼 (학번, 서명, 비고) - 비워두기
                 for (int i = 0; i < 3; i++) {
                     Cell c = row.createCell(cellIndex++);
                     c.setCellValue("");
@@ -129,7 +121,6 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
                 }
             }
 
-            // 파일명/헤더
             String fileName = "Program_Participant_Information";
             res.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
             res.setHeader("Content-Disposition", "attachment; filename=" + fileName + ".xlsx");

--- a/src/main/java/team/startup/expo/domain/excel/service/impl/ProgramParticipantInfoToExcelServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/excel/service/impl/ProgramParticipantInfoToExcelServiceImpl.java
@@ -1,4 +1,5 @@
 package team.startup.expo.domain.excel.service.impl;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletResponse;
@@ -29,6 +30,7 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
     private final StandardProgramUserRepository standardProgramUserRepository;
     private final StandardProgramRepository standardProgramRepository;
     private final DynamicJsonDataRepository dynamicJsonDataRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public void execute(String expoId, Long programId, HttpServletResponse res) {
         try (Workbook workbook = new XSSFWorkbook()) {
@@ -65,13 +67,18 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
             List<String> headers = new ArrayList<>(List.of("순위", "이름", "전화번호", "개인정보 동의 여부"));
 
             Set<String> infoDynamicKeys = new LinkedHashSet<>();
-            if (!standardParticipants.isEmpty()) {
-                StandardParticipant first = standardParticipants.get(0);
-                DynamicJsonData firstInfo = dynamicJsonDataRepository
-                        .findByOwnerTypeAndOwnerId(OwnerType.STANDARD_PARTICIPANT, first.getId())
+            for (StandardParticipant sp : standardParticipants) {
+                DynamicJsonData doc = dynamicJsonDataRepository
+                        .findByOwnerTypeAndOwnerId(OwnerType.STANDARD_PARTICIPANT, sp.getId())
                         .orElse(null);
-                if (firstInfo != null && firstInfo.getAnswers() != null) {
-                    infoDynamicKeys.addAll(firstInfo.getAnswers().keySet());
+                if (doc != null && doc.getAnswers() != null) {
+                    try {
+                        Map parsed = objectMapper.readValue(doc.getAnswers(), Map.class);
+                        for (Object k : parsed.keySet()) {
+                            infoDynamicKeys.add(String.valueOf(k));
+                        }
+                    } catch (Exception ignore) {
+                    }
                 }
             }
 
@@ -98,19 +105,25 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
                 row.createCell(cellIndex++).setCellValue(participant.getPhoneNumber());
                 row.createCell(cellIndex++).setCellValue(Boolean.TRUE.equals(participant.getPersonalInformationStatus()) ? "동의" : "미동의");
 
-                Map<String, String> infoJsonMap = new HashMap<>();
+                Map infoJsonMap = new HashMap();
                 DynamicJsonData infoDoc = dynamicJsonDataRepository
                         .findByOwnerTypeAndOwnerId(OwnerType.STANDARD_PARTICIPANT, participant.getId())
                         .orElse(null);
                 if (infoDoc != null && infoDoc.getAnswers() != null) {
-                    for (Map.Entry<String, Object> entry : infoDoc.getAnswers().entrySet()) {
-                        infoJsonMap.put(entry.getKey(), entry.getValue() != null ? String.valueOf(entry.getValue()) : "");
+                    try {
+                        Map parsed = objectMapper.readValue(infoDoc.getAnswers(), Map.class);
+                        for (Object k : parsed.keySet()) {
+                            Object v = parsed.get(k);
+                            infoJsonMap.put(k, v != null ? String.valueOf(v) : "");
+                        }
+                    } catch (Exception ignore) {
                     }
                 }
 
                 for (String key : infoDynamicKeys) {
                     Cell c = row.createCell(cellIndex++);
-                    c.setCellValue(infoJsonMap.getOrDefault(key, ""));
+                    Object v = infoJsonMap.containsKey(key) ? infoJsonMap.get(key) : "";
+                    c.setCellValue(String.valueOf(v));
                     c.setCellStyle(bodyStyle);
                 }
 

--- a/src/main/java/team/startup/expo/domain/excel/service/impl/StandardParticipantInfoToExcelServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/excel/service/impl/StandardParticipantInfoToExcelServiceImpl.java
@@ -15,6 +15,9 @@ import team.startup.expo.domain.excel.service.StandardParticipantInfoToExcelServ
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.mongo.entity.DynamicJsonData;
+import team.startup.expo.domain.mongo.entity.OwnerType;
+import team.startup.expo.domain.mongo.repository.DynamicJsonDataRepository;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.participant.repository.StandardParticipantRepository;
 import team.startup.expo.domain.survey.answer.entity.StandardParticipantSurveyAnswer;
@@ -33,6 +36,7 @@ public class StandardParticipantInfoToExcelServiceImpl implements StandardPartic
     private final StandardParticipantRepository standardParticipantRepository;
     private final ExpoRepository expoRepository;
     private final StandardParticipantSurveyAnswerRepository standardParticipantSurveyAnswerRepository;
+    private final DynamicJsonDataRepository dynamicJsonDataRepository;
 
     private String sanitizeJson(String json) {
         if (json == null) return null;
@@ -97,11 +101,11 @@ public class StandardParticipantInfoToExcelServiceImpl implements StandardPartic
             StandardParticipant firstParticipant = standardParticipantList.get(0);
 
             Set<String> infoDynamicKeys = new LinkedHashSet<>();
-            String infoHeaderJson = firstParticipant.getInformationJson();
-            if (infoHeaderJson != null) {
-                String sanitizedInfoHeaderJson = sanitizeJson(infoHeaderJson);
-                Map<String, String> infoHeaderJsonMap = objectMapper.readValue(sanitizedInfoHeaderJson, Map.class);
-                infoDynamicKeys.addAll(infoHeaderJsonMap.keySet());
+            DynamicJsonData firstInfo = dynamicJsonDataRepository
+                    .findByOwnerTypeAndOwnerId(OwnerType.STANDARD_PARTICIPANT, firstParticipant.getId())
+                    .orElse(null);
+            if (firstInfo != null && firstInfo.getAnswers() != null) {
+                infoDynamicKeys.addAll(firstInfo.getAnswers().keySet());
             }
 
             Set<String> surveyDynamicKeys = new LinkedHashSet<>();
@@ -151,10 +155,13 @@ public class StandardParticipantInfoToExcelServiceImpl implements StandardPartic
                 applyTypeCell.setCellStyle(bodyStyle);
 
                 Map<String, String> infoJsonMap = new HashMap<>();
-                String escapedInfoJson = participant.getInformationJson();
-                if (escapedInfoJson != null) {
-                    String sanitizedInfoJson = sanitizeJson(escapedInfoJson);
-                    infoJsonMap = objectMapper.readValue(sanitizedInfoJson, Map.class);
+                DynamicJsonData infoDoc = dynamicJsonDataRepository
+                        .findByOwnerTypeAndOwnerId(OwnerType.STANDARD_PARTICIPANT, participant.getId())
+                        .orElse(null);
+                if (infoDoc != null && infoDoc.getAnswers() != null) {
+                    for (Map.Entry<String, Object> entry : infoDoc.getAnswers().entrySet()) {
+                        infoJsonMap.put(entry.getKey(), entry.getValue() != null ? String.valueOf(entry.getValue()) : "");
+                    }
                 }
 
                 for (String key : infoDynamicKeys) {

--- a/src/main/java/team/startup/expo/domain/excel/service/impl/StandardParticipantInfoToExcelServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/excel/service/impl/StandardParticipantInfoToExcelServiceImpl.java
@@ -105,7 +105,11 @@ public class StandardParticipantInfoToExcelServiceImpl implements StandardPartic
                     .findByOwnerTypeAndOwnerId(OwnerType.STANDARD_PARTICIPANT, firstParticipant.getId())
                     .orElse(null);
             if (firstInfo != null && firstInfo.getAnswers() != null) {
-                infoDynamicKeys.addAll(firstInfo.getAnswers().keySet());
+                try {
+                    String sanitizedInfoHeaderJson = sanitizeJson(firstInfo.getAnswers());
+                    Map infoHeaderMap = objectMapper.readValue(sanitizedInfoHeaderJson, Map.class);
+                    infoDynamicKeys.addAll(infoHeaderMap.keySet());
+                } catch (Exception ignored) {}
             }
 
             Set<String> surveyDynamicKeys = new LinkedHashSet<>();
@@ -113,10 +117,11 @@ public class StandardParticipantInfoToExcelServiceImpl implements StandardPartic
             for (StandardParticipant participant : standardParticipantList) {
                 StandardParticipantSurveyAnswer answer = participantSurveyAnswerMap.get(participant.getId());
                 if (answer != null && answer.getAnswerJson() != null) {
-                    String sanitizedSurveyHeaderJson = sanitizeJson(answer.getAnswerJson());
-                    Map<String, String> surveyHeaderJsonMap = objectMapper.readValue(sanitizedSurveyHeaderJson, Map.class);
-                    surveyDynamicKeys.addAll(surveyHeaderJsonMap.keySet());
-                    break;
+                    try {
+                        String sanitizedSurveyHeaderJson = sanitizeJson(answer.getAnswerJson());
+                        Map surveyHeaderJsonMap = objectMapper.readValue(sanitizedSurveyHeaderJson, Map.class);
+                        surveyDynamicKeys.addAll(surveyHeaderJsonMap.keySet());
+                    } catch (Exception ignored) {}
                 }
             }
 
@@ -154,32 +159,37 @@ public class StandardParticipantInfoToExcelServiceImpl implements StandardPartic
                 }
                 applyTypeCell.setCellStyle(bodyStyle);
 
-                Map<String, String> infoJsonMap = new HashMap<>();
+                Map infoJsonMap = new HashMap();
                 DynamicJsonData infoDoc = dynamicJsonDataRepository
                         .findByOwnerTypeAndOwnerId(OwnerType.STANDARD_PARTICIPANT, participant.getId())
                         .orElse(null);
                 if (infoDoc != null && infoDoc.getAnswers() != null) {
-                    for (Map.Entry<String, Object> entry : infoDoc.getAnswers().entrySet()) {
-                        infoJsonMap.put(entry.getKey(), entry.getValue() != null ? String.valueOf(entry.getValue()) : "");
-                    }
+                    try {
+                        String sanitizedInfoJson = sanitizeJson(infoDoc.getAnswers());
+                        infoJsonMap = objectMapper.readValue(sanitizedInfoJson, Map.class);
+                    } catch (Exception ignored) {}
                 }
 
                 for (String key : infoDynamicKeys) {
+                    Object v = infoJsonMap.containsKey(key) ? infoJsonMap.get(key) : "";
                     Cell cell = row.createCell(cellIndex++);
-                    cell.setCellValue(infoJsonMap.getOrDefault(key, ""));
+                    cell.setCellValue(v != null ? String.valueOf(v) : "");
                     cell.setCellStyle(bodyStyle);
                 }
 
-                Map<String, String> answerJsonMap = new HashMap<>();
+                Map answerJsonMap = new HashMap();
                 StandardParticipantSurveyAnswer surveyAnswer = participantSurveyAnswerMap.get(participant.getId());
                 if (surveyAnswer != null && surveyAnswer.getAnswerJson() != null) {
-                    String sanitizedAnswerJson = sanitizeJson(surveyAnswer.getAnswerJson());
-                    answerJsonMap = objectMapper.readValue(sanitizedAnswerJson, Map.class);
+                    try {
+                        String sanitizedAnswerJson = sanitizeJson(surveyAnswer.getAnswerJson());
+                        answerJsonMap = objectMapper.readValue(sanitizedAnswerJson, Map.class);
+                    } catch (Exception ignored) {}
                 }
 
                 for (String key : surveyDynamicKeys) {
+                    Object v = answerJsonMap.containsKey(key) ? answerJsonMap.get(key) : "";
                     Cell cell = row.createCell(cellIndex++);
-                    cell.setCellValue(answerJsonMap.getOrDefault(key, ""));
+                    cell.setCellValue(v != null ? String.valueOf(v) : "");
                     cell.setCellStyle(bodyStyle);
                 }
             }

--- a/src/main/java/team/startup/expo/domain/excel/service/impl/TraineeInfoToExcelServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/excel/service/impl/TraineeInfoToExcelServiceImpl.java
@@ -1,5 +1,6 @@
 package team.startup.expo.domain.excel.service.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,8 @@ import java.util.*;
 @ReadOnlyTransactionService
 @RequiredArgsConstructor
 public class TraineeInfoToExcelServiceImpl implements TraineeInfoToExcelService {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final TraineeRepository traineeRepository;
     private final ExpoRepository expoRepository;
@@ -66,8 +69,12 @@ public class TraineeInfoToExcelServiceImpl implements TraineeInfoToExcelService 
                 DynamicJsonData infoDoc = dynamicJsonDataRepository
                         .findByOwnerTypeAndOwnerId(OwnerType.TRAINEE, trainee.getId())
                         .orElse(null);
-                if (infoDoc != null && infoDoc.getAnswers() != null) {
-                    dynamicKeys.addAll(infoDoc.getAnswers().keySet());
+                if (infoDoc != null && infoDoc.getAnswers() != null && !infoDoc.getAnswers().isBlank()) {
+                    Map<String, String> parsed = OBJECT_MAPPER.readValue(
+                            infoDoc.getAnswers(),
+                            Map.class
+                    );
+                    dynamicKeys.addAll(parsed.keySet());
                 }
             }
 
@@ -92,9 +99,13 @@ public class TraineeInfoToExcelServiceImpl implements TraineeInfoToExcelService 
                 DynamicJsonData infoDoc = dynamicJsonDataRepository
                         .findByOwnerTypeAndOwnerId(OwnerType.TRAINEE, trainee.getId())
                         .orElse(null);
-                if (infoDoc != null && infoDoc.getAnswers() != null) {
-                    for (Map.Entry<String, Object> entry : infoDoc.getAnswers().entrySet()) {
-                        jsonMap.put(entry.getKey(), entry.getValue() != null ? String.valueOf(entry.getValue()) : "");
+                if (infoDoc != null && infoDoc.getAnswers() != null && !infoDoc.getAnswers().isBlank()) {
+                    Map<String, String> parsed = OBJECT_MAPPER.readValue(
+                            infoDoc.getAnswers(),
+                            Map.class
+                    );
+                    for (Map.Entry<String, String> entry : parsed.entrySet()) {
+                        jsonMap.put(entry.getKey(), entry.getValue() != null ? entry.getValue() : "");
                     }
                 }
 

--- a/src/main/java/team/startup/expo/domain/excel/service/impl/TraineeInfoToExcelServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/excel/service/impl/TraineeInfoToExcelServiceImpl.java
@@ -1,11 +1,8 @@
 package team.startup.expo.domain.excel.service.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFColor;
@@ -15,6 +12,9 @@ import team.startup.expo.domain.excel.service.TraineeInfoToExcelService;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.mongo.entity.DynamicJsonData;
+import team.startup.expo.domain.mongo.entity.OwnerType;
+import team.startup.expo.domain.mongo.repository.DynamicJsonDataRepository;
 import team.startup.expo.domain.trainee.entity.Trainee;
 import team.startup.expo.domain.trainee.repository.TraineeRepository;
 import team.startup.expo.global.annotation.ReadOnlyTransactionService;
@@ -27,9 +27,9 @@ public class TraineeInfoToExcelServiceImpl implements TraineeInfoToExcelService 
 
     private final TraineeRepository traineeRepository;
     private final ExpoRepository expoRepository;
-    private final ObjectMapper objectMapper = new ObjectMapper(); // JSON 변환기
+    private final DynamicJsonDataRepository dynamicJsonDataRepository;
 
-    public void execute(String expoId, HttpServletResponse res) throws JsonProcessingException {
+    public void execute(String expoId, HttpServletResponse res) {
         try {
             Expo expo = expoRepository.findById(expoId)
                     .orElseThrow(NotFoundExpoException::new);
@@ -62,16 +62,14 @@ public class TraineeInfoToExcelServiceImpl implements TraineeInfoToExcelService 
             // 기본 헤더
             List<String> headers = new ArrayList<>(List.of("이름", "연수원아이디", "전화번호", "신청방식"));
 
-            // 모든 Trainee의 JSON key를 모아서 dynamicKeys 생성
+            // 모든 Trainee의 Mongo answers key를 모아서 dynamicKeys 생성
             Set<String> dynamicKeys = new LinkedHashSet<>();
             for (Trainee trainee : traineeList) {
-                String escapedJson = trainee.getInformationJson();
-                if (escapedJson != null) {
-                    try {
-                        String unescapedJson = StringEscapeUtils.unescapeJson(escapedJson);
-                        Map<String, String> jsonMap = objectMapper.readValue(unescapedJson, Map.class);
-                        dynamicKeys.addAll(jsonMap.keySet());
-                    } catch (Exception ignored) {}
+                DynamicJsonData infoDoc = dynamicJsonDataRepository
+                        .findByOwnerTypeAndOwnerId(OwnerType.TRAINEE, trainee.getId())
+                        .orElse(null);
+                if (infoDoc != null && infoDoc.getAnswers() != null) {
+                    dynamicKeys.addAll(infoDoc.getAnswers().keySet());
                 }
             }
 
@@ -94,12 +92,13 @@ public class TraineeInfoToExcelServiceImpl implements TraineeInfoToExcelService 
                 row.createCell(3).setCellValue(trainee.getApplicationType().toString());
 
                 Map<String, String> jsonMap = new HashMap<>();
-                String escapedJson = trainee.getInformationJson();
-                if (escapedJson != null) {
-                    try {
-                        String unescapedJson = StringEscapeUtils.unescapeJson(escapedJson);
-                        jsonMap = objectMapper.readValue(unescapedJson, Map.class);
-                    } catch (Exception ignored) {}
+                DynamicJsonData infoDoc = dynamicJsonDataRepository
+                        .findByOwnerTypeAndOwnerId(OwnerType.TRAINEE, trainee.getId())
+                        .orElse(null);
+                if (infoDoc != null && infoDoc.getAnswers() != null) {
+                    for (Map.Entry<String, Object> entry : infoDoc.getAnswers().entrySet()) {
+                        jsonMap.put(entry.getKey(), entry.getValue() != null ? String.valueOf(entry.getValue()) : "");
+                    }
                 }
 
                 int cellIndex = 4;

--- a/src/main/java/team/startup/expo/domain/excel/service/impl/TraineeInfoToExcelServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/excel/service/impl/TraineeInfoToExcelServiceImpl.java
@@ -59,10 +59,8 @@ public class TraineeInfoToExcelServiceImpl implements TraineeInfoToExcelService 
             bodyStyle.setBorderLeft(BorderStyle.THIN);
             bodyStyle.setBorderRight(BorderStyle.THIN);
 
-            // 기본 헤더
             List<String> headers = new ArrayList<>(List.of("이름", "연수원아이디", "전화번호", "신청방식"));
 
-            // 모든 Trainee의 Mongo answers key를 모아서 dynamicKeys 생성
             Set<String> dynamicKeys = new LinkedHashSet<>();
             for (Trainee trainee : traineeList) {
                 DynamicJsonData infoDoc = dynamicJsonDataRepository
@@ -75,7 +73,6 @@ public class TraineeInfoToExcelServiceImpl implements TraineeInfoToExcelService 
 
             headers.addAll(dynamicKeys);
 
-            // 헤더 생성
             Row headerRow = sheet.createRow(0);
             for (int i = 0; i < headers.size(); i++) {
                 Cell cell = headerRow.createCell(i);

--- a/src/main/java/team/startup/expo/domain/form/entity/DynamicForm.java
+++ b/src/main/java/team/startup/expo/domain/form/entity/DynamicForm.java
@@ -5,14 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
-import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.mongo.entity.DynamicFormJsonDoc;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 @Getter
 @Table(name = "tb_dynamic_form")
 public class DynamicForm {
@@ -22,9 +19,12 @@ public class DynamicForm {
     private Long id;
 
     @Column(nullable = false)
+    private Long formId;
+
+    @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Transient
     private String jsonData;
 
     @Enumerated(EnumType.STRING)
@@ -34,11 +34,18 @@ public class DynamicForm {
     @Column(nullable = false)
     private Boolean requiredStatus;
 
-    @Column(columnDefinition = "TEXT")
+    @Transient
     private String otherJson;
 
-    @JoinColumn(name = "form_id")
-    @ManyToOne
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    private Form form;
+    @Transient
+    private DynamicFormJsonDoc formJson;
+
+    @Builder
+    private DynamicForm(Long id, Long formId, String title, FormType formType, Boolean requiredStatus) {
+        this.id = id;
+        this.formId = formId;
+        this.title = title;
+        this.formType = formType;
+        this.requiredStatus = requiredStatus;
+    }
 }

--- a/src/main/java/team/startup/expo/domain/form/presentation/dto/request/FormRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/form/presentation/dto/request/FormRequestDto.java
@@ -36,11 +36,11 @@ public class FormRequestDto {
         private FormType formType;
 
         @NotNull
-        private Map<String, Object> jsonData;
+        private String jsonData;
 
         @NotNull
         private Boolean requiredStatus;
 
-        private Map<String, Object> otherJson;
+        private String otherJson;
     }
 }

--- a/src/main/java/team/startup/expo/domain/form/presentation/dto/request/FormRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/form/presentation/dto/request/FormRequestDto.java
@@ -1,12 +1,14 @@
 package team.startup.expo.domain.form.presentation.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.Valid;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team.startup.expo.domain.form.entity.FormType;
 import team.startup.expo.domain.form.entity.ParticipationType;
 
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @NoArgsConstructor
@@ -17,6 +19,7 @@ public class FormRequestDto {
     @NotNull
     private ParticipationType participantType;
 
+    @Valid
     @NotNull
     private List<DynamicFormRequestDto> dynamicForm;
 
@@ -30,11 +33,11 @@ public class FormRequestDto {
         private FormType formType;
 
         @NotNull
-        private String jsonData;
+        private Map<String, Object> jsonData;
 
         @NotNull
         private Boolean requiredStatus;
 
-        private String otherJson;
+        private Map<String, Object> otherJson;
     }
 }

--- a/src/main/java/team/startup/expo/domain/form/presentation/dto/response/GetFormResponseDto.java
+++ b/src/main/java/team/startup/expo/domain/form/presentation/dto/response/GetFormResponseDto.java
@@ -28,8 +28,8 @@ public class GetFormResponseDto {
     public static class DynamicFormRequestDto {
         private String title;
         private FormType formType;
-        private Map<String, Object> jsonData;
+        private String jsonData;
         private Boolean requiredStatus;
-        private Map<String, Object> otherJson;
+        private String otherJson;
     }
 }

--- a/src/main/java/team/startup/expo/domain/form/presentation/dto/response/GetFormResponseDto.java
+++ b/src/main/java/team/startup/expo/domain/form/presentation/dto/response/GetFormResponseDto.java
@@ -8,6 +8,7 @@ import team.startup.expo.domain.form.entity.FormType;
 import team.startup.expo.domain.form.entity.ParticipationType;
 
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @AllArgsConstructor
@@ -25,8 +26,8 @@ public class GetFormResponseDto {
     public static class DynamicFormRequestDto {
         private String title;
         private FormType formType;
-        private String jsonData;
+        private Map<String, Object> jsonData;
         private Boolean requiredStatus;
-        private String otherJson;
+        private Map<String, Object> otherJson;
     }
 }

--- a/src/main/java/team/startup/expo/domain/form/repository/DynamicFormRepository.java
+++ b/src/main/java/team/startup/expo/domain/form/repository/DynamicFormRepository.java
@@ -7,6 +7,5 @@ import team.startup.expo.domain.form.repository.custom.DynamicFormCustomReposito
 import java.util.List;
 
 public interface DynamicFormRepository extends JpaRepository<DynamicForm, Long>, DynamicFormCustomRepository {
-    long deleteByFormId(Long formId);
     List<DynamicForm> findByFormId(Long formId);
 }

--- a/src/main/java/team/startup/expo/domain/form/repository/DynamicFormRepository.java
+++ b/src/main/java/team/startup/expo/domain/form/repository/DynamicFormRepository.java
@@ -2,11 +2,10 @@ package team.startup.expo.domain.form.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.startup.expo.domain.form.entity.DynamicForm;
-import team.startup.expo.domain.form.entity.Form;
 
 import java.util.List;
 
 public interface DynamicFormRepository extends JpaRepository<DynamicForm, Long> {
-    void deleteByForm(Form form);
-    List<DynamicForm> findByForm(Form form);
+    void deleteByFormId(Long formId);
+    List<DynamicForm> findByFormId(Long formId);
 }

--- a/src/main/java/team/startup/expo/domain/form/repository/DynamicFormRepository.java
+++ b/src/main/java/team/startup/expo/domain/form/repository/DynamicFormRepository.java
@@ -2,10 +2,11 @@ package team.startup.expo.domain.form.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.startup.expo.domain.form.entity.DynamicForm;
+import team.startup.expo.domain.form.repository.custom.DynamicFormCustomRepository;
 
 import java.util.List;
 
-public interface DynamicFormRepository extends JpaRepository<DynamicForm, Long> {
-    void deleteByFormId(Long formId);
+public interface DynamicFormRepository extends JpaRepository<DynamicForm, Long>, DynamicFormCustomRepository {
+    long deleteByFormId(Long formId);
     List<DynamicForm> findByFormId(Long formId);
 }

--- a/src/main/java/team/startup/expo/domain/form/repository/custom/DynamicFormCustomRepository.java
+++ b/src/main/java/team/startup/expo/domain/form/repository/custom/DynamicFormCustomRepository.java
@@ -1,0 +1,8 @@
+package team.startup.expo.domain.form.repository.custom;
+
+import java.util.List;
+
+public interface DynamicFormCustomRepository {
+    List<Long> findIdsByFormId(Long formId);
+    long deleteByFormId(Long formId);
+}

--- a/src/main/java/team/startup/expo/domain/form/repository/custom/impl/DynamicFormCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/repository/custom/impl/DynamicFormCustomRepositoryImpl.java
@@ -1,0 +1,34 @@
+package team.startup.expo.domain.form.repository.custom.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import team.startup.expo.domain.form.repository.custom.DynamicFormCustomRepository;
+
+import java.util.List;
+
+import static team.startup.expo.domain.form.entity.QDynamicForm.dynamicForm;
+
+@Repository
+@RequiredArgsConstructor
+public class DynamicFormCustomRepositoryImpl implements DynamicFormCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Long> findIdsByFormId(Long formId) {
+        return queryFactory
+                .select(dynamicForm.id)
+                .from(dynamicForm)
+                .where(dynamicForm.formId.eq(formId))
+                .fetch();
+    }
+
+    @Override
+    public long deleteByFormId(Long formId) {
+        return queryFactory
+                .delete(dynamicForm)
+                .where(dynamicForm.formId.eq(formId))
+                .execute();
+    }
+}

--- a/src/main/java/team/startup/expo/domain/form/service/impl/CreateFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/CreateFormServiceImpl.java
@@ -11,6 +11,8 @@ import team.startup.expo.domain.form.presentation.dto.request.FormRequestDto;
 import team.startup.expo.domain.form.repository.DynamicFormRepository;
 import team.startup.expo.domain.form.repository.FormRepository;
 import team.startup.expo.domain.form.service.CreateFormService;
+import team.startup.expo.domain.mongo.entity.DynamicFormJsonDoc;
+import team.startup.expo.domain.mongo.repository.DynamicFormJsonRepository;
 import team.startup.expo.global.annotation.TransactionService;
 
 @TransactionService
@@ -20,6 +22,7 @@ public class CreateFormServiceImpl implements CreateFormService {
     private final FormRepository formRepository;
     private final DynamicFormRepository dynamicFormRepository;
     private final ExpoRepository expoRepository;
+    private final DynamicFormJsonRepository dynamicFormJsonRepository;
 
     public void execute(String expoId, FormRequestDto formRequestDto) {
         Expo expo = expoRepository.findById(expoId)
@@ -30,7 +33,7 @@ public class CreateFormServiceImpl implements CreateFormService {
 
         Form form = saveForm(formRequestDto, expo);
 
-        formRequestDto.getDynamicForm().forEach(dynamicForm -> {saveDynamicForm(dynamicForm, form);});
+        formRequestDto.getDynamicForm().forEach(df -> saveDynamicForm(df, form));
     }
 
     private Form saveForm(FormRequestDto formRequestDto, Expo expo) {
@@ -45,14 +48,19 @@ public class CreateFormServiceImpl implements CreateFormService {
 
     private void saveDynamicForm(FormRequestDto.DynamicFormRequestDto dynamicFormRequestDto, Form form) {
         DynamicForm dynamicForm = DynamicForm.builder()
+                .formId(form.getId())
                 .title(dynamicFormRequestDto.getTitle())
-                .jsonData(dynamicFormRequestDto.getJsonData())
                 .formType(dynamicFormRequestDto.getFormType())
                 .requiredStatus(dynamicFormRequestDto.getRequiredStatus())
-                .otherJson(dynamicFormRequestDto.getOtherJson())
-                .form(form)
                 .build();
+        dynamicForm = dynamicFormRepository.save(dynamicForm);
 
-        dynamicFormRepository.save(dynamicForm);
+        DynamicFormJsonDoc doc = new DynamicFormJsonDoc(
+                null,
+                dynamicForm.getId(),
+                dynamicFormRequestDto.getJsonData(),
+                dynamicFormRequestDto.getOtherJson()
+        );
+        dynamicFormJsonRepository.save(doc);
     }
 }

--- a/src/main/java/team/startup/expo/domain/form/service/impl/DeleteFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/DeleteFormServiceImpl.java
@@ -6,13 +6,17 @@ import org.springframework.cache.annotation.CacheEvict;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.form.entity.DynamicForm;
 import team.startup.expo.domain.form.entity.Form;
 import team.startup.expo.domain.form.entity.ParticipationType;
 import team.startup.expo.domain.form.exception.NotFoundFormException;
 import team.startup.expo.domain.form.repository.DynamicFormRepository;
 import team.startup.expo.domain.form.repository.FormRepository;
 import team.startup.expo.domain.form.service.DeleteFormService;
+import team.startup.expo.domain.mongo.repository.DynamicFormJsonRepository;
 import team.startup.expo.global.annotation.TransactionService;
+
+import java.util.List;
 
 @TransactionService
 @RequiredArgsConstructor
@@ -22,6 +26,7 @@ public class DeleteFormServiceImpl implements DeleteFormService {
     private final ExpoRepository expoRepository;
     private final FormRepository formRepository;
     private final DynamicFormRepository dynamicFormRepository;
+    private final DynamicFormJsonRepository dynamicFormJsonRepository;
 
     @CacheEvict(key = "#expoId + '_' + #participationType", cacheNames = "cacheManager")
     public void execute(String expoId, ParticipationType participationType) {
@@ -31,7 +36,11 @@ public class DeleteFormServiceImpl implements DeleteFormService {
         Form form = formRepository.findByExpoAndParticipationType(expo, participationType)
                 .orElseThrow(NotFoundFormException::new);
 
-        dynamicFormRepository.deleteByForm(form);
+        List<DynamicForm> dynamicForms = dynamicFormRepository.findByFormId(form.getId());
+        for (DynamicForm df : dynamicForms) {
+            dynamicFormJsonRepository.deleteByRecordId(df.getId());
+        }
+        dynamicFormRepository.deleteAll(dynamicForms);
         formRepository.delete(form);
     }
 }

--- a/src/main/java/team/startup/expo/domain/form/service/impl/DeleteFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/DeleteFormServiceImpl.java
@@ -6,7 +6,6 @@ import org.springframework.cache.annotation.CacheEvict;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
-import team.startup.expo.domain.form.entity.DynamicForm;
 import team.startup.expo.domain.form.entity.Form;
 import team.startup.expo.domain.form.entity.ParticipationType;
 import team.startup.expo.domain.form.exception.NotFoundFormException;
@@ -36,11 +35,14 @@ public class DeleteFormServiceImpl implements DeleteFormService {
         Form form = formRepository.findByExpoAndParticipationType(expo, participationType)
                 .orElseThrow(NotFoundFormException::new);
 
-        List<DynamicForm> dynamicForms = dynamicFormRepository.findByFormId(form.getId());
-        for (DynamicForm df : dynamicForms) {
-            dynamicFormJsonRepository.deleteByRecordId(df.getId());
+        List<Long> dynamicFormIds = dynamicFormRepository.findIdsByFormId(form.getId());
+
+        if (!dynamicFormIds.isEmpty()) {
+            dynamicFormJsonRepository.deleteByRecordIdIn(dynamicFormIds);
         }
-        dynamicFormRepository.deleteAll(dynamicForms);
+
+        dynamicFormRepository.deleteByFormId(form.getId());
+
         formRepository.delete(form);
     }
 }

--- a/src/main/java/team/startup/expo/domain/form/service/impl/GetFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/GetFormServiceImpl.java
@@ -20,6 +20,8 @@ import team.startup.expo.domain.trainee.entity.ApplicationType;
 import team.startup.expo.global.annotation.ReadOnlyTransactionService;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @ReadOnlyTransactionService
 @RequiredArgsConstructor
@@ -41,9 +43,16 @@ public class GetFormServiceImpl implements GetFormService {
 
         List<DynamicForm> dynamicFormList = dynamicFormRepository.findByFormId(form.getId());
 
+        List<Long> ids = dynamicFormList.stream()
+                .map(DynamicForm::getId)
+                .toList();
+
+        Map<Long, DynamicFormJsonDoc> docMap = dynamicFormJsonRepository.findByRecordIdIn(ids).stream()
+                .collect(Collectors.toMap(DynamicFormJsonDoc::getRecordId, d -> d));
+
         List<GetFormResponseDto.DynamicFormRequestDto> dynamicFormRequestDtoList = dynamicFormList.stream()
                 .map(dynamicForm -> {
-                    DynamicFormJsonDoc doc = dynamicFormJsonRepository.findByRecordId(dynamicForm.getId()).orElse(null);
+                    DynamicFormJsonDoc doc = docMap.get(dynamicForm.getId());
                     return GetFormResponseDto.DynamicFormRequestDto.builder()
                             .title(dynamicForm.getTitle())
                             .jsonData(doc != null ? doc.getJsonData() : null)

--- a/src/main/java/team/startup/expo/domain/form/service/impl/GetFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/GetFormServiceImpl.java
@@ -14,6 +14,8 @@ import team.startup.expo.domain.form.presentation.dto.response.GetFormResponseDt
 import team.startup.expo.domain.form.repository.DynamicFormRepository;
 import team.startup.expo.domain.form.repository.FormRepository;
 import team.startup.expo.domain.form.service.GetFormService;
+import team.startup.expo.domain.mongo.entity.DynamicFormJsonDoc;
+import team.startup.expo.domain.mongo.repository.DynamicFormJsonRepository;
 import team.startup.expo.global.annotation.ReadOnlyTransactionService;
 
 import java.util.List;
@@ -26,6 +28,7 @@ public class GetFormServiceImpl implements GetFormService {
     private final FormRepository formRepository;
     private final ExpoRepository expoRepository;
     private final DynamicFormRepository dynamicFormRepository;
+    private final DynamicFormJsonRepository dynamicFormJsonRepository;
 
     @Cacheable(key = "#expoId + '_' + #participationType", cacheManager = "cacheManager")
     public GetFormResponseDto execute(String expoId, ParticipationType participationType) {
@@ -35,17 +38,19 @@ public class GetFormServiceImpl implements GetFormService {
         Form form = formRepository.findByExpoAndParticipationType(expo, participationType)
                 .orElseThrow(NotFoundFormException::new);
 
-        List<DynamicForm> dynamicFormList = dynamicFormRepository.findByForm(form);
+        List<DynamicForm> dynamicFormList = dynamicFormRepository.findByFormId(form.getId());
 
         List<GetFormResponseDto.DynamicFormRequestDto> dynamicFormRequestDtoList = dynamicFormList.stream()
-                .map(dynamicForm -> GetFormResponseDto.DynamicFormRequestDto.builder()
-                        .title(dynamicForm.getTitle())
-                        .jsonData(dynamicForm.getJsonData())
-                        .formType(dynamicForm.getFormType())
-                        .requiredStatus(dynamicForm.getRequiredStatus())
-                        .otherJson(dynamicForm.getOtherJson())
-                        .build()
-                ).toList();
+                .map(dynamicForm -> {
+                    DynamicFormJsonDoc doc = dynamicFormJsonRepository.findByRecordId(dynamicForm.getId()).orElse(null);
+                    return GetFormResponseDto.DynamicFormRequestDto.builder()
+                            .title(dynamicForm.getTitle())
+                            .jsonData(doc != null ? doc.getJsonData() : null)
+                            .formType(dynamicForm.getFormType())
+                            .requiredStatus(dynamicForm.getRequiredStatus())
+                            .otherJson(doc != null ? doc.getOtherJson() : null)
+                            .build();
+                }).toList();
 
         return GetFormResponseDto.builder()
                 .informationText(form.getInformationText())

--- a/src/main/java/team/startup/expo/domain/form/service/impl/UpdateFormServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/form/service/impl/UpdateFormServiceImpl.java
@@ -12,6 +12,8 @@ import team.startup.expo.domain.form.presentation.dto.request.FormRequestDto;
 import team.startup.expo.domain.form.repository.DynamicFormRepository;
 import team.startup.expo.domain.form.repository.FormRepository;
 import team.startup.expo.domain.form.service.UpdateFormService;
+import team.startup.expo.domain.mongo.entity.DynamicFormJsonDoc;
+import team.startup.expo.domain.mongo.repository.DynamicFormJsonRepository;
 import team.startup.expo.global.annotation.TransactionService;
 
 @TransactionService
@@ -22,6 +24,7 @@ public class UpdateFormServiceImpl implements UpdateFormService {
     private final ExpoRepository expoRepository;
     private final FormRepository formRepository;
     private final DynamicFormRepository dynamicFormRepository;
+    private final DynamicFormJsonRepository dynamicFormJsonRepository;
 
     @CacheEvict(key = "#expoId + '_' + #dto.participantType", cacheManager = "cacheManager")
     public void execute(String expoId, FormRequestDto dto) {
@@ -31,22 +34,25 @@ public class UpdateFormServiceImpl implements UpdateFormService {
         Form form = formRepository.findByExpoAndParticipationType(expo, dto.getParticipantType())
                 .orElseThrow(NotFoundFormException::new);
 
-        dynamicFormRepository.deleteByForm(form);
-
         form.updateForm(dto);
         dto.getDynamicForm().forEach(dynamicForm -> {saveDynamicForm(dynamicForm, form);});
     }
 
     private void saveDynamicForm(FormRequestDto.DynamicFormRequestDto dto, Form form) {
         DynamicForm updateDynamicForm = DynamicForm.builder()
+                .formId(form.getId())
                 .title(dto.getTitle())
                 .formType(dto.getFormType())
-                .jsonData(dto.getJsonData())
                 .requiredStatus(dto.getRequiredStatus())
-                .otherJson(dto.getOtherJson())
-                .form(form)
                 .build();
+        updateDynamicForm = dynamicFormRepository.save(updateDynamicForm);
 
-        dynamicFormRepository.save(updateDynamicForm);
+        DynamicFormJsonDoc doc = new DynamicFormJsonDoc(
+                null,
+                updateDynamicForm.getId(),
+                dto.getJsonData(),
+                dto.getOtherJson()
+        );
+        dynamicFormJsonRepository.save(doc);
     }
 }

--- a/src/main/java/team/startup/expo/domain/mongo/entity/DynamicFormJsonDoc.java
+++ b/src/main/java/team/startup/expo/domain/mongo/entity/DynamicFormJsonDoc.java
@@ -20,7 +20,7 @@ public class DynamicFormJsonDoc {
     @Indexed(unique = true)
     private Long recordId;
 
-    private Map<String, Object> jsonData;
+    private String jsonData;
 
-    private Map<String, Object> otherJson;
+    private String otherJson;
 }

--- a/src/main/java/team/startup/expo/domain/mongo/entity/DynamicFormJsonDoc.java
+++ b/src/main/java/team/startup/expo/domain/mongo/entity/DynamicFormJsonDoc.java
@@ -1,0 +1,26 @@
+package team.startup.expo.domain.mongo.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(collection = "dynamic_form_json")
+public class DynamicFormJsonDoc {
+    @Id
+    private String id;
+
+    @Indexed(unique = true)
+    private Long recordId;
+
+    private Map<String, Object> jsonData;
+
+    private Map<String, Object> otherJson;
+}

--- a/src/main/java/team/startup/expo/domain/mongo/entity/DynamicJsonData.java
+++ b/src/main/java/team/startup/expo/domain/mongo/entity/DynamicJsonData.java
@@ -1,0 +1,29 @@
+package team.startup.expo.domain.mongo.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "participant_answer_json")
+@CompoundIndex(def = "{'ownerType': 1, 'ownerId': 1}", unique = true)
+public class DynamicJsonData {
+    @Id
+    private String id;
+
+    @Indexed
+    private OwnerType ownerType;
+
+    @Indexed
+    private Long ownerId;
+
+    private Map<String, Object> answers;
+}

--- a/src/main/java/team/startup/expo/domain/mongo/entity/DynamicJsonData.java
+++ b/src/main/java/team/startup/expo/domain/mongo/entity/DynamicJsonData.java
@@ -25,5 +25,5 @@ public class DynamicJsonData {
     @Indexed
     private Long ownerId;
 
-    private Map<String, Object> answers;
+    private String answers;
 }

--- a/src/main/java/team/startup/expo/domain/mongo/entity/DynamicSurveyJsonDoc.java
+++ b/src/main/java/team/startup/expo/domain/mongo/entity/DynamicSurveyJsonDoc.java
@@ -1,0 +1,27 @@
+package team.startup.expo.domain.mongo.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(collection = "dynamic_survey_json")
+public class DynamicSurveyJsonDoc {
+
+    @Id
+    private String id;
+
+    @Indexed(unique = true)
+    private Long recordId;
+
+    private Map<String, Object> jsonData;
+
+    private Map<String, Object> otherJson;
+}

--- a/src/main/java/team/startup/expo/domain/mongo/entity/DynamicSurveyJsonDoc.java
+++ b/src/main/java/team/startup/expo/domain/mongo/entity/DynamicSurveyJsonDoc.java
@@ -21,7 +21,7 @@ public class DynamicSurveyJsonDoc {
     @Indexed(unique = true)
     private Long recordId;
 
-    private Map<String, Object> jsonData;
+    private String jsonData;
 
-    private Map<String, Object> otherJson;
+    private String otherJson;
 }

--- a/src/main/java/team/startup/expo/domain/mongo/entity/OwnerType.java
+++ b/src/main/java/team/startup/expo/domain/mongo/entity/OwnerType.java
@@ -1,0 +1,5 @@
+package team.startup.expo.domain.mongo.entity;
+
+public enum OwnerType {
+    TRAINEE, STANDARD_PARTICIPANT
+}

--- a/src/main/java/team/startup/expo/domain/mongo/repository/DynamicFormJsonRepository.java
+++ b/src/main/java/team/startup/expo/domain/mongo/repository/DynamicFormJsonRepository.java
@@ -1,0 +1,12 @@
+package team.startup.expo.domain.mongo.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import team.startup.expo.domain.mongo.entity.DynamicFormJsonDoc;
+
+import java.util.Optional;
+
+public interface DynamicFormJsonRepository extends MongoRepository<DynamicFormJsonDoc, String> {
+    Optional<DynamicFormJsonDoc> findByRecordId(Long recordId);
+    void deleteByRecordId(Long recordId);
+
+}

--- a/src/main/java/team/startup/expo/domain/mongo/repository/DynamicFormJsonRepository.java
+++ b/src/main/java/team/startup/expo/domain/mongo/repository/DynamicFormJsonRepository.java
@@ -5,9 +5,11 @@ import team.startup.expo.domain.mongo.entity.DynamicFormJsonDoc;
 
 import java.util.Optional;
 import java.util.Collection;
+import java.util.List;
 
 public interface DynamicFormJsonRepository extends MongoRepository<DynamicFormJsonDoc, String> {
     Optional<DynamicFormJsonDoc> findByRecordId(Long recordId);
+    List<DynamicFormJsonDoc> findByRecordIdIn(Collection<Long> recordIds);
     void deleteByRecordIdIn(Collection<Long> recordIds);
 
 }

--- a/src/main/java/team/startup/expo/domain/mongo/repository/DynamicFormJsonRepository.java
+++ b/src/main/java/team/startup/expo/domain/mongo/repository/DynamicFormJsonRepository.java
@@ -4,9 +4,10 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import team.startup.expo.domain.mongo.entity.DynamicFormJsonDoc;
 
 import java.util.Optional;
+import java.util.Collection;
 
 public interface DynamicFormJsonRepository extends MongoRepository<DynamicFormJsonDoc, String> {
     Optional<DynamicFormJsonDoc> findByRecordId(Long recordId);
-    void deleteByRecordId(Long recordId);
+    void deleteByRecordIdIn(Collection<Long> recordIds);
 
 }

--- a/src/main/java/team/startup/expo/domain/mongo/repository/DynamicJsonDataRepository.java
+++ b/src/main/java/team/startup/expo/domain/mongo/repository/DynamicJsonDataRepository.java
@@ -1,0 +1,11 @@
+package team.startup.expo.domain.mongo.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import team.startup.expo.domain.mongo.entity.DynamicJsonData;
+import team.startup.expo.domain.mongo.entity.OwnerType;
+
+import java.util.Optional;
+
+public interface DynamicJsonDataRepository extends MongoRepository<DynamicJsonData, String> {
+    Optional<DynamicJsonData> findByOwnerTypeAndOwnerId(OwnerType ownerType, Long ownerId);
+}

--- a/src/main/java/team/startup/expo/domain/mongo/repository/DynamicSurveyJsonRepository.java
+++ b/src/main/java/team/startup/expo/domain/mongo/repository/DynamicSurveyJsonRepository.java
@@ -4,9 +4,11 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import team.startup.expo.domain.mongo.entity.DynamicSurveyJsonDoc;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface DynamicSurveyJsonRepository extends MongoRepository<DynamicSurveyJsonDoc, String> {
     Optional<DynamicSurveyJsonDoc> findByRecordId(Long recordId);
     void deleteByRecordIdIn(Collection<Long> recordIds);
+    List<DynamicSurveyJsonDoc> findByRecordIdIn(Collection<Long> recordIds);
 }

--- a/src/main/java/team/startup/expo/domain/mongo/repository/DynamicSurveyJsonRepository.java
+++ b/src/main/java/team/startup/expo/domain/mongo/repository/DynamicSurveyJsonRepository.java
@@ -1,0 +1,11 @@
+package team.startup.expo.domain.mongo.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import team.startup.expo.domain.mongo.entity.DynamicSurveyJsonDoc;
+
+import java.util.Optional;
+
+public interface DynamicSurveyJsonRepository extends MongoRepository<DynamicSurveyJsonDoc, String> {
+    Optional<DynamicSurveyJsonDoc> findByRecordId(Long recordId);
+    void deleteByRecordId(Long recordId);
+}

--- a/src/main/java/team/startup/expo/domain/mongo/repository/DynamicSurveyJsonRepository.java
+++ b/src/main/java/team/startup/expo/domain/mongo/repository/DynamicSurveyJsonRepository.java
@@ -3,9 +3,10 @@ package team.startup.expo.domain.mongo.repository;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import team.startup.expo.domain.mongo.entity.DynamicSurveyJsonDoc;
 
+import java.util.Collection;
 import java.util.Optional;
 
 public interface DynamicSurveyJsonRepository extends MongoRepository<DynamicSurveyJsonDoc, String> {
     Optional<DynamicSurveyJsonDoc> findByRecordId(Long recordId);
-    void deleteByRecordId(Long recordId);
+    void deleteByRecordIdIn(Collection<Long> recordIds);
 }

--- a/src/main/java/team/startup/expo/domain/participant/entity/StandardParticipant.java
+++ b/src/main/java/team/startup/expo/domain/participant/entity/StandardParticipant.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.admin.entity.Authority;
 import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.mongo.entity.DynamicJsonData;
 import team.startup.expo.domain.trainee.entity.ApplicationType;
 
 @Entity
@@ -29,8 +30,8 @@ public class StandardParticipant {
     @Column(nullable = false, columnDefinition = "VARCHAR(15)")
     private String phoneNumber;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String informationJson;
+    @Transient
+    private DynamicJsonData participantJson;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/team/startup/expo/domain/survey/management/entity/DynamicSurvey.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/entity/DynamicSurvey.java
@@ -5,9 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.form.entity.FormType;
+import team.startup.expo.domain.mongo.entity.DynamicSurveyJsonDoc;
 
 @Entity
 @NoArgsConstructor
@@ -22,9 +21,12 @@ public class DynamicSurvey {
     private Long id;
 
     @Column(nullable = false)
+    private Long surveyId;
+
+    @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Transient
     private String jsonData;
 
     @Enumerated(EnumType.STRING)
@@ -34,11 +36,9 @@ public class DynamicSurvey {
     @Column(nullable = false)
     private Boolean requiredStatus;
 
-    @Column(columnDefinition = "TEXT")
+    @Transient
     private String otherJson;
 
-    @ManyToOne
-    @JoinColumn(name = "survey_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    private Survey survey;
+    @Transient
+    private DynamicSurveyJsonDoc dynamicSurveyJsonDoc;
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/presentation/dto/request/SurveyRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/presentation/dto/request/SurveyRequestDto.java
@@ -30,7 +30,7 @@ public class SurveyRequestDto {
         private String title;
 
         @NotNull
-        private Map<String, Object> jsonData;
+        private String jsonData;
 
         @NotNull
         private FormType formType;
@@ -38,6 +38,6 @@ public class SurveyRequestDto {
         @NotNull
         private Boolean requiredStatus;
 
-        private Map<String, Object> otherJson;
+        private String otherJson;
     }
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/presentation/dto/request/SurveyRequestDto.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/presentation/dto/request/SurveyRequestDto.java
@@ -1,5 +1,6 @@
 package team.startup.expo.domain.survey.management.presentation.dto.request;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,6 +8,7 @@ import team.startup.expo.domain.form.entity.FormType;
 import team.startup.expo.domain.form.entity.ParticipationType;
 
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @NoArgsConstructor
@@ -17,6 +19,7 @@ public class SurveyRequestDto {
     @NotNull
     private String informationText;
 
+    @Valid
     @NotNull
     private List<DynamicSurveyRequestDto> dynamicSurveyRequestDto;
 
@@ -27,7 +30,7 @@ public class SurveyRequestDto {
         private String title;
 
         @NotNull
-        private String jsonData;
+        private Map<String, Object> jsonData;
 
         @NotNull
         private FormType formType;
@@ -35,6 +38,6 @@ public class SurveyRequestDto {
         @NotNull
         private Boolean requiredStatus;
 
-        private String otherJson;
+        private Map<String, Object> otherJson;
     }
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/presentation/dto/response/SurveyResponseDto.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/presentation/dto/response/SurveyResponseDto.java
@@ -8,6 +8,7 @@ import team.startup.expo.domain.form.entity.FormType;
 import team.startup.expo.domain.form.entity.ParticipationType;
 
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @AllArgsConstructor
@@ -24,9 +25,9 @@ public class SurveyResponseDto {
     @NoArgsConstructor
     public static class DynamicSurveyResponseDto {
         private String title;
-        private String jsonData;
+        private Map<String, Object> jsonData;
         private FormType formType;
         private Boolean requiredStatus;
-        private String otherJson;
+        private Map<String, Object> otherJson;
     }
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/presentation/dto/response/SurveyResponseDto.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/presentation/dto/response/SurveyResponseDto.java
@@ -25,9 +25,9 @@ public class SurveyResponseDto {
     @NoArgsConstructor
     public static class DynamicSurveyResponseDto {
         private String title;
-        private Map<String, Object> jsonData;
+        private String jsonData;
         private FormType formType;
         private Boolean requiredStatus;
-        private Map<String, Object> otherJson;
+        private String otherJson;
     }
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/repository/DynamicSurveyRepository.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/repository/DynamicSurveyRepository.java
@@ -1,15 +1,11 @@
 package team.startup.expo.domain.survey.management.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-
 import team.startup.expo.domain.survey.management.entity.DynamicSurvey;
-import team.startup.expo.domain.survey.management.entity.Survey;
 
 import java.util.List;
 
 public interface DynamicSurveyRepository extends JpaRepository<DynamicSurvey, Long> {
-    List<DynamicSurvey> findBySurvey(Survey survey);
-    @Modifying(clearAutomatically = true)
-    void deleteBySurvey(Survey survey);
+    void deleteBySurveyId(Long surveyId);
+    List<DynamicSurvey> findBySurveyId(Long surveyId);
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/repository/DynamicSurveyRepository.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/repository/DynamicSurveyRepository.java
@@ -2,10 +2,10 @@ package team.startup.expo.domain.survey.management.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.startup.expo.domain.survey.management.entity.DynamicSurvey;
+import team.startup.expo.domain.survey.management.repository.custom.DynamicSurveyCustomRepository;
 
 import java.util.List;
 
-public interface DynamicSurveyRepository extends JpaRepository<DynamicSurvey, Long> {
-    void deleteBySurveyId(Long surveyId);
+public interface DynamicSurveyRepository extends JpaRepository<DynamicSurvey, Long>, DynamicSurveyCustomRepository {
     List<DynamicSurvey> findBySurveyId(Long surveyId);
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/repository/custom/DynamicSurveyCustomRepository.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/repository/custom/DynamicSurveyCustomRepository.java
@@ -1,0 +1,8 @@
+package team.startup.expo.domain.survey.management.repository.custom;
+
+import java.util.List;
+
+public interface DynamicSurveyCustomRepository {
+    List<Long> findIdsBySurveyId(Long surveyId);
+    long deleteBySurveyId(Long surveyId);
+}

--- a/src/main/java/team/startup/expo/domain/survey/management/repository/custom/impl/DynamicSurveyCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/repository/custom/impl/DynamicSurveyCustomRepositoryImpl.java
@@ -1,0 +1,34 @@
+package team.startup.expo.domain.survey.management.repository.custom.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import team.startup.expo.domain.survey.management.repository.custom.DynamicSurveyCustomRepository;
+
+import java.util.List;
+
+import static team.startup.expo.domain.survey.management.entity.QDynamicSurvey.dynamicSurvey;
+
+@Repository
+@RequiredArgsConstructor
+public class DynamicSurveyCustomRepositoryImpl implements DynamicSurveyCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Long> findIdsBySurveyId(Long surveyId) {
+        return queryFactory
+                .select(dynamicSurvey.id)
+                .from(dynamicSurvey)
+                .where(dynamicSurvey.surveyId.eq(surveyId))
+                .fetch();
+    }
+
+    @Override
+    public long deleteBySurveyId(Long surveyId) {
+        return queryFactory
+                .delete(dynamicSurvey)
+                .where(dynamicSurvey.surveyId.eq(surveyId))
+                .execute();
+    }
+}

--- a/src/main/java/team/startup/expo/domain/survey/management/service/impl/CreateSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/impl/CreateSurveyServiceImpl.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.mongo.entity.DynamicSurveyJsonDoc;
+import team.startup.expo.domain.mongo.repository.DynamicSurveyJsonRepository;
 import team.startup.expo.domain.survey.management.entity.DynamicSurvey;
 import team.startup.expo.domain.survey.management.entity.Survey;
 import team.startup.expo.domain.survey.management.exception.AlreadyExistSurveyException;
@@ -20,6 +22,7 @@ public class CreateSurveyServiceImpl implements CreateSurveyService {
     private final SurveyRepository surveyRepository;
     private final DynamicSurveyRepository dynamicSurveyRepository;
     private final ExpoRepository expoRepository;
+    private final DynamicSurveyJsonRepository dynamicSurveyJsonRepository;
 
     public void execute(String expoId, SurveyRequestDto dto) {
         Expo expo = expoRepository.findById(expoId)
@@ -46,14 +49,19 @@ public class CreateSurveyServiceImpl implements CreateSurveyService {
 
     private void saveDynamicSurvey(SurveyRequestDto.DynamicSurveyRequestDto dto, Survey survey) {
         DynamicSurvey dynamicSurvey = DynamicSurvey.builder()
+                .surveyId(survey.getId())
                 .title(dto.getTitle())
-                .jsonData(dto.getJsonData())
                 .formType(dto.getFormType())
                 .requiredStatus(dto.getRequiredStatus())
-                .otherJson(dto.getOtherJson())
-                .survey(survey)
                 .build();
+        dynamicSurvey = dynamicSurveyRepository.save(dynamicSurvey);
 
-        dynamicSurveyRepository.save(dynamicSurvey);
+        DynamicSurveyJsonDoc doc = new DynamicSurveyJsonDoc(
+                null,
+                dynamicSurvey.getId(),
+                dto.getJsonData(),
+                dto.getOtherJson()
+        );
+        dynamicSurveyJsonRepository.save(doc);
     }
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/service/impl/DeleteSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/impl/DeleteSurveyServiceImpl.java
@@ -7,7 +7,6 @@ import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.form.entity.ParticipationType;
-import team.startup.expo.domain.survey.management.entity.DynamicSurvey;
 import team.startup.expo.domain.survey.management.entity.Survey;
 import team.startup.expo.domain.survey.management.exception.NotFoundSurveyException;
 import team.startup.expo.domain.survey.management.repository.DynamicSurveyRepository;
@@ -36,11 +35,13 @@ public class DeleteSurveyServiceImpl implements DeleteSurveyService {
         Survey survey = surveyRepository.findByExpoAndParticipationType(expo, participationType)
                 .orElseThrow(NotFoundSurveyException::new);
 
-        List<DynamicSurvey> dynamicSurveys = dynamicSurveyRepository.findBySurveyId(survey.getId());
-        for (DynamicSurvey ds : dynamicSurveys) {
-            dynamicSurveyJsonRepository.deleteByRecordId(ds.getId());
+        List<Long> dynamicSurveyIds = dynamicSurveyRepository.findIdsBySurveyId(survey.getId());
+
+        if (!dynamicSurveyIds.isEmpty()) {
+            dynamicSurveyJsonRepository.deleteByRecordIdIn(dynamicSurveyIds);
         }
-        dynamicSurveyRepository.deleteAll(dynamicSurveys);
+
+        dynamicSurveyRepository.deleteBySurveyId(survey.getId());
         surveyRepository.delete(survey);
     }
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/service/impl/DeleteSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/impl/DeleteSurveyServiceImpl.java
@@ -7,12 +7,16 @@ import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.form.entity.ParticipationType;
+import team.startup.expo.domain.survey.management.entity.DynamicSurvey;
 import team.startup.expo.domain.survey.management.entity.Survey;
 import team.startup.expo.domain.survey.management.exception.NotFoundSurveyException;
 import team.startup.expo.domain.survey.management.repository.DynamicSurveyRepository;
 import team.startup.expo.domain.survey.management.repository.SurveyRepository;
 import team.startup.expo.domain.survey.management.service.DeleteSurveyService;
+import team.startup.expo.domain.mongo.repository.DynamicSurveyJsonRepository;
 import team.startup.expo.global.annotation.TransactionService;
+
+import java.util.List;
 
 @TransactionService
 @RequiredArgsConstructor
@@ -22,6 +26,7 @@ public class DeleteSurveyServiceImpl implements DeleteSurveyService {
     private final SurveyRepository surveyRepository;
     private final DynamicSurveyRepository dynamicSurveyRepository;
     private final ExpoRepository expoRepository;
+    private final DynamicSurveyJsonRepository dynamicSurveyJsonRepository;
 
     @CacheEvict(key = "#expoId + '_' + #participationType", cacheManager = "cacheManager")
     public void execute(String expoId, ParticipationType participationType) {
@@ -31,7 +36,11 @@ public class DeleteSurveyServiceImpl implements DeleteSurveyService {
         Survey survey = surveyRepository.findByExpoAndParticipationType(expo, participationType)
                 .orElseThrow(NotFoundSurveyException::new);
 
-        dynamicSurveyRepository.deleteBySurvey(survey);
+        List<DynamicSurvey> dynamicSurveys = dynamicSurveyRepository.findBySurveyId(survey.getId());
+        for (DynamicSurvey ds : dynamicSurveys) {
+            dynamicSurveyJsonRepository.deleteByRecordId(ds.getId());
+        }
+        dynamicSurveyRepository.deleteAll(dynamicSurveys);
         surveyRepository.delete(survey);
     }
 }

--- a/src/main/java/team/startup/expo/domain/survey/management/service/impl/GetSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/impl/GetSurveyServiceImpl.java
@@ -19,6 +19,8 @@ import team.startup.expo.domain.survey.management.service.GetSurveyService;
 import team.startup.expo.global.annotation.ReadOnlyTransactionService;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @ReadOnlyTransactionService
 @RequiredArgsConstructor
@@ -40,9 +42,15 @@ public class GetSurveyServiceImpl implements GetSurveyService {
 
         List<DynamicSurvey> dynamicSurveyList = dynamicSurveyRepository.findBySurveyId(survey.getId());
 
+        List<Long> ids = dynamicSurveyList.stream()
+                .map(DynamicSurvey::getId)
+                .toList();
+        Map<Long, DynamicSurveyJsonDoc> docMap = dynamicSurveyJsonRepository.findByRecordIdIn(ids).stream()
+                .collect(Collectors.toMap(DynamicSurveyJsonDoc::getRecordId, d -> d));
+
         List<SurveyResponseDto.DynamicSurveyResponseDto> dynamicSurveyResponseDto = dynamicSurveyList.stream()
                 .map(dynamicSurvey -> {
-                    DynamicSurveyJsonDoc doc = dynamicSurveyJsonRepository.findByRecordId(dynamicSurvey.getId()).orElse(null);
+                    DynamicSurveyJsonDoc doc = docMap.get(dynamicSurvey.getId());
                     return SurveyResponseDto.DynamicSurveyResponseDto.builder()
                         .title(dynamicSurvey.getTitle())
                         .jsonData(doc != null ? doc.getJsonData() : null)

--- a/src/main/java/team/startup/expo/domain/survey/management/service/impl/GetSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/impl/GetSurveyServiceImpl.java
@@ -7,6 +7,8 @@ import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
 import team.startup.expo.domain.form.entity.ParticipationType;
+import team.startup.expo.domain.mongo.entity.DynamicSurveyJsonDoc;
+import team.startup.expo.domain.mongo.repository.DynamicSurveyJsonRepository;
 import team.startup.expo.domain.survey.management.entity.DynamicSurvey;
 import team.startup.expo.domain.survey.management.entity.Survey;
 import team.startup.expo.domain.survey.management.exception.NotFoundSurveyException;
@@ -26,6 +28,7 @@ public class GetSurveyServiceImpl implements GetSurveyService {
     private final SurveyRepository surveyRepository;
     private final DynamicSurveyRepository dynamicSurveyRepository;
     private final ExpoRepository expoRepository;
+    private final DynamicSurveyJsonRepository dynamicSurveyJsonRepository;
 
     @Cacheable(key = "#expoId + '_' + #participationType", cacheManager = "cacheManager")
     public SurveyResponseDto execute(String expoId, ParticipationType participationType) {
@@ -35,17 +38,19 @@ public class GetSurveyServiceImpl implements GetSurveyService {
         Survey survey = surveyRepository.findByExpoAndParticipationType(expo, participationType)
                 .orElseThrow(NotFoundSurveyException::new);
 
-        List<DynamicSurvey> dynamicSurveyList = dynamicSurveyRepository.findBySurvey(survey);
+        List<DynamicSurvey> dynamicSurveyList = dynamicSurveyRepository.findBySurveyId(survey.getId());
 
         List<SurveyResponseDto.DynamicSurveyResponseDto> dynamicSurveyResponseDto = dynamicSurveyList.stream()
-                .map(dynamicSurvey -> SurveyResponseDto.DynamicSurveyResponseDto.builder()
+                .map(dynamicSurvey -> {
+                    DynamicSurveyJsonDoc doc = dynamicSurveyJsonRepository.findByRecordId(dynamicSurvey.getId()).orElse(null);
+                    return SurveyResponseDto.DynamicSurveyResponseDto.builder()
                         .title(dynamicSurvey.getTitle())
-                        .jsonData(dynamicSurvey.getJsonData())
+                        .jsonData(doc != null ? doc.getJsonData() : null)
                         .formType(dynamicSurvey.getFormType())
                         .requiredStatus(dynamicSurvey.getRequiredStatus())
-                        .otherJson(dynamicSurvey.getOtherJson())
-                        .build()
-                ).toList();
+                        .otherJson(doc != null ? doc.getOtherJson() : null)
+                        .build();
+                }).toList();
 
         return SurveyResponseDto.builder()
                 .informationText(survey.getInformationText())

--- a/src/main/java/team/startup/expo/domain/survey/management/service/impl/UpdateSurveyServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/survey/management/service/impl/UpdateSurveyServiceImpl.java
@@ -6,6 +6,8 @@ import org.springframework.cache.annotation.CacheEvict;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.expo.repository.ExpoRepository;
+import team.startup.expo.domain.mongo.entity.DynamicSurveyJsonDoc;
+import team.startup.expo.domain.mongo.repository.DynamicSurveyJsonRepository;
 import team.startup.expo.domain.survey.management.entity.DynamicSurvey;
 import team.startup.expo.domain.survey.management.entity.Survey;
 import team.startup.expo.domain.survey.management.exception.NotFoundSurveyException;
@@ -23,6 +25,7 @@ public class UpdateSurveyServiceImpl implements UpdateSurveyService {
     private final SurveyRepository surveyRepository;
     private final DynamicSurveyRepository dynamicSurveyRepository;
     private final ExpoRepository expoRepository;
+    private final DynamicSurveyJsonRepository dynamicSurveyJsonRepository;
 
     @CacheEvict(key = "#expoId + '_' + #dto.participationType", cacheManager = "cacheManager")
     public void execute(String expoId, SurveyRequestDto dto) {
@@ -33,20 +36,24 @@ public class UpdateSurveyServiceImpl implements UpdateSurveyService {
                 .orElseThrow(NotFoundSurveyException::new);
 
         survey.update(dto.getInformationText());
-        dynamicSurveyRepository.deleteBySurvey(survey);
         dto.getDynamicSurveyRequestDto().forEach(dynamicSurveyRequestDto -> saveDynamicSurvey(dynamicSurveyRequestDto, survey));
     }
 
     private void saveDynamicSurvey(SurveyRequestDto.DynamicSurveyRequestDto dto, Survey survey) {
         DynamicSurvey dynamicSurvey = DynamicSurvey.builder()
+                .surveyId(survey.getId())
                 .title(dto.getTitle())
-                .jsonData(dto.getJsonData())
                 .formType(dto.getFormType())
                 .requiredStatus(dto.getRequiredStatus())
-                .otherJson(dto.getOtherJson())
-                .survey(survey)
                 .build();
+        dynamicSurvey = dynamicSurveyRepository.save(dynamicSurvey);
 
-        dynamicSurveyRepository.save(dynamicSurvey);
+        DynamicSurveyJsonDoc doc = new DynamicSurveyJsonDoc(
+                null,
+                dynamicSurvey.getId(),
+                dto.getJsonData(),
+                dto.getOtherJson()
+        );
+        dynamicSurveyJsonRepository.save(doc);
     }
 }

--- a/src/main/java/team/startup/expo/domain/trainee/entity/Trainee.java
+++ b/src/main/java/team/startup/expo/domain/trainee/entity/Trainee.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import team.startup.expo.domain.admin.entity.Authority;
 import team.startup.expo.domain.expo.entity.Expo;
+import team.startup.expo.domain.mongo.entity.DynamicJsonData;
 
 @Entity
 @NoArgsConstructor
@@ -31,8 +32,8 @@ public class Trainee {
     @Column(nullable = false, columnDefinition = "VARCHAR(15)")
     private String trainingId;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String informationJson;
+    @Transient
+    private DynamicJsonData traineeJson;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: ${DB_DRIVER_CLASS}
     url: jdbc:mysql://${DB_HOST:localhost}:3306/${DB_NAME:expo}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
     username: ${DB_USER:root}
     password: ${DB_PASSWORD:12345}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    driver-class-name: ${DB_DRIVER_CLASS}
+    driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${DB_HOST:localhost}:3306/${DB_NAME:expo}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
     username: ${DB_USER:root}
     password: ${DB_PASSWORD:12345}
@@ -17,6 +17,9 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+    mongodb:
+      uri: ${MONGO_URI}
+      auto-index-creation: true
 
 jwt:
   accessSecret: ${JWT_ACCESS_SECRET}


### PR DESCRIPTION
## 💡 배경 및 개요
 
기존 시스템에서는 DynamicForm, DynamicSurvey, Trainee, StandardParticipant의 기본 정보인 정적데이터, 
동적인 JSON 데이터가 모두 RDB에 저장되고 있었습니다. 그러나 DynamicForm, DynamicSurvey같이 자주 변하는 
동적 JSON 필드를 RDB에 저장하는 방식은 확장성과 유지보수 측면에서 좋지 않다고 생각했습니다.

그래서 DynamicForm, DynamicSurvey, Trainee, StandardParticipant 엔티티의 정적 데이터들은 기존처럼 RDB에 저장하고,
동적 JSON 데이터는 MongoDB로 분리하여 저장하도록 개선하였습니다.

Resolves: #316

## 📃 작업내용

- Form 및 Survey 엔티티의 동적 JSON 필드 제거 및 MongoDB 전용 Document 엔티티로 분리
-  DynamicForm, DynamicSurvey 엔티티는 정적 메타 필드만 유지하도록 구조 변경

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타