### PR TITLE
참가자 조회 페이징 쿼리 성능 개선

### DIFF
--- a/src/main/java/team/startup/expo/domain/participant/repository/custom/impl/ParticipantCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/custom/impl/ParticipantCustomRepositoryImpl.java
@@ -1,10 +1,10 @@
 package team.startup.expo.domain.participant.repository.custom.impl;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-import team.startup.expo.domain.participant.entity.StandardParticipant;
 import team.startup.expo.domain.participant.presentation.dto.response.GetParticipantInfoResponseDto;
 import team.startup.expo.domain.participant.presentation.dto.response.ParticipantResponseDto;
 import team.startup.expo.domain.participant.repository.custom.ParticipantCustomRepository;
@@ -12,7 +12,6 @@ import team.startup.expo.domain.participant.repository.custom.ParticipantCustomR
 import java.time.LocalDate;
 import java.util.List;
 
-import static team.startup.expo.domain.expo.entity.QExpo.expo;
 import static team.startup.expo.domain.participant.entity.QStandardParticipant.standardParticipant;
 import static team.startup.expo.domain.participant.entity.QStandardParticipantParticipation.standardParticipantParticipation;
 
@@ -26,7 +25,7 @@ public class ParticipantCustomRepositoryImpl implements ParticipantCustomReposit
         int size = pageable.getPageSize();
 
         Long totalElement = queryFactory
-                .select(standardParticipant.count())
+                .select(standardParticipant.id.count())
                 .from(standardParticipant)
                 .join(standardParticipantParticipation).on(standardParticipantParticipation.standardParticipant.eq(standardParticipant))
                 .where(
@@ -37,8 +36,15 @@ public class ParticipantCustomRepositoryImpl implements ParticipantCustomReposit
 
         int totalPage = (int) ((totalElement + size - 1) / size);
 
-        List<StandardParticipant> participants = queryFactory
-                .selectFrom(standardParticipant)
+        List<GetParticipantInfoResponseDto> participants = queryFactory
+                .select(Projections.constructor(
+                        GetParticipantInfoResponseDto.class,
+                        standardParticipant.id,
+                        standardParticipant.name,
+                        standardParticipant.personalInformationStatus,
+                        standardParticipant.phoneNumber
+                ))
+                .from(standardParticipant)
                 .join(standardParticipantParticipation).on(standardParticipantParticipation.standardParticipant.eq(standardParticipant))
                 .where(
                         standardParticipant.expo.id.eq(expoId)
@@ -48,21 +54,12 @@ public class ParticipantCustomRepositoryImpl implements ParticipantCustomReposit
                 .limit(size)
                 .fetch();
 
-        List<GetParticipantInfoResponseDto> getParticipantInfoResponseDto = participants.stream()
-                .map(participant -> GetParticipantInfoResponseDto.builder()
-                        .id(participant.getId())
-                        .name(participant.getName())
-                        .informationStatus(participant.getPersonalInformationStatus())
-                        .phoneNumber(participant.getPhoneNumber())
-                        .build())
-                .toList();
-
         return ParticipantResponseDto.builder()
                 .info(ParticipantResponseDto.Info.builder()
                         .totalPage(totalPage)
                         .totalElement(totalElement.intValue())
                         .build())
-                .participants(getParticipantInfoResponseDto)
+                .participants(participants)
                 .build();
 
     }

--- a/src/main/java/team/startup/expo/domain/participant/repository/custom/impl/ParticipantCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/expo/domain/participant/repository/custom/impl/ParticipantCustomRepositoryImpl.java
@@ -41,8 +41,8 @@ public class ParticipantCustomRepositoryImpl implements ParticipantCustomReposit
                         GetParticipantInfoResponseDto.class,
                         standardParticipant.id,
                         standardParticipant.name,
-                        standardParticipant.personalInformationStatus,
-                        standardParticipant.phoneNumber
+                        standardParticipant.phoneNumber,
+                        standardParticipant.personalInformationStatus
                 ))
                 .from(standardParticipant)
                 .join(standardParticipantParticipation).on(standardParticipantParticipation.standardParticipant.eq(standardParticipant))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,11 +7,17 @@ spring:
   jpa:
     hibernate:
       dialect: ${DB_DIALECT}
-      ddl-auto: update
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: true
     show-sql: true
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:data.sql
+      encoding: UTF-8
+      continue-on-error: false
   jackson:
     time-zone: Asia/Seoul
   mvc:


### PR DESCRIPTION
## 💡 배경 및 개요

> 참가자 조회 페이징 쿼리를 인덱스 + DTO Projection 구조로 개선하였습니다.
> 참가자 조회 시 `StandardParticipant` 엔티티의 모든 컬럼을 조회한 후 Java의 Stream을 이용해 Response DTO를 생성하는 구조에서 DTO Projection을 이용하여 필요한 컬럼만 가져오도록 구조를 개선하였습니다.

Resolves: #{이슈번호}

## 📃 작업내용

> DTO Projection 구조로 개선
> 인덱스 설계

## 🙋‍♂️ 리뷰노트

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타