### PR TITLE
엑셀 메모리 성능 개선

### DIFF
--- a/src/main/java/team/startup/expo/domain/excel/service/impl/ProgramParticipantInfoToExcelServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/excel/service/impl/ProgramParticipantInfoToExcelServiceImpl.java
@@ -4,9 +4,7 @@ import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.apache.poi.ss.usermodel.*;
-import org.apache.poi.xssf.usermodel.XSSFCellStyle;
-import org.apache.poi.xssf.usermodel.XSSFFont;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import team.startup.expo.domain.attendance.exception.NotFoundStandardProgramException;
 import team.startup.expo.domain.excel.service.ProgramParticipantInfoToExcelService;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
@@ -27,23 +25,22 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
     private final StandardProgramRepository standardProgramRepository;
 
     public void execute(String expoId, Long programId, HttpServletResponse res) {
-        try (Workbook workbook = new XSSFWorkbook()) {
+        try (SXSSFWorkbook workbook = new SXSSFWorkbook(500)) {
+            workbook.setCompressTempFiles(true);
+
             StandardProgram standardProgram = standardProgramRepository.findByIdAndExpoId(programId, expoId)
                     .orElseThrow(NotFoundStandardProgramException::new);
 
             List<StandardProgramUser> standardProgramUsers = standardProgramUserRepository.findByStandardProgram(standardProgram);
-            List<StandardParticipant> standardParticipants = standardProgramUsers.stream()
-                    .map(StandardProgramUser::getStandardParticipant)
-                    .toList();
 
             Sheet sheet = workbook.createSheet("프로그램 참가자 정보");
             sheet.setDefaultColumnWidth(20);
 
-            XSSFFont headerFont = (XSSFFont) workbook.createFont();
+            Font headerFont = workbook.createFont();
             headerFont.setBold(true);
-            headerFont.setColor((short) IndexedColors.WHITE.getIndex());
+            headerFont.setColor(IndexedColors.WHITE.getIndex());
 
-            XSSFCellStyle headerStyle = (XSSFCellStyle) workbook.createCellStyle();
+            CellStyle headerStyle = workbook.createCellStyle();
             headerStyle.setFillForegroundColor(IndexedColors.BLACK.getIndex());
             headerStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
             headerStyle.setBorderTop(BorderStyle.THIN);
@@ -52,7 +49,7 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
             headerStyle.setBorderRight(BorderStyle.THIN);
             headerStyle.setFont(headerFont);
 
-            XSSFCellStyle bodyStyle = (XSSFCellStyle) workbook.createCellStyle();
+            CellStyle bodyStyle = workbook.createCellStyle();
             bodyStyle.setBorderTop(BorderStyle.THIN);
             bodyStyle.setBorderBottom(BorderStyle.THIN);
             bodyStyle.setBorderLeft(BorderStyle.THIN);
@@ -72,14 +69,28 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
 
             int rowCount = 1;
             int rank = 1;
-            for (StandardParticipant participant : standardParticipants) {
+            for (StandardProgramUser spu : standardProgramUsers) {
+                StandardParticipant participant = spu.getStandardParticipant();
+
                 Row row = sheet.createRow(rowCount++);
 
                 int cellIndex = 0;
-                row.createCell(cellIndex++).setCellValue(rank++); // 순위
-                row.createCell(cellIndex++).setCellValue(participant.getName());
-                row.createCell(cellIndex++).setCellValue(participant.getPhoneNumber());
-                row.createCell(cellIndex++).setCellValue(Boolean.TRUE.equals(participant.getPersonalInformationStatus()) ? "동의" : "미동의");
+
+                Cell rankCell = row.createCell(cellIndex++);
+                rankCell.setCellValue(rank++);
+                rankCell.setCellStyle(bodyStyle);
+
+                Cell nameCell = row.createCell(cellIndex++);
+                nameCell.setCellValue(participant.getName());
+                nameCell.setCellStyle(bodyStyle);
+
+                Cell phoneCell = row.createCell(cellIndex++);
+                phoneCell.setCellValue(participant.getPhoneNumber());
+                phoneCell.setCellStyle(bodyStyle);
+
+                Cell consentCell = row.createCell(cellIndex++);
+                consentCell.setCellValue(Boolean.TRUE.equals(participant.getPersonalInformationStatus()) ? "동의" : "미동의");
+                consentCell.setCellStyle(bodyStyle);
 
                 for (int i = 0; i < 3; i++) {
                     Cell c = row.createCell(cellIndex++);
@@ -90,11 +101,13 @@ public class ProgramParticipantInfoToExcelServiceImpl implements ProgramParticip
 
             String fileName = "Program_Participant_Information";
             res.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-            res.setHeader("Content-Disposition", "attachment; filename=" + fileName + ".xlsx");
+            res.setHeader("Content-Disposition", "attachment; filename=\"" + fileName + ".xlsx\"");
 
             try (ServletOutputStream outputStream = res.getOutputStream()) {
                 workbook.write(outputStream);
                 outputStream.flush();
+            } finally {
+                workbook.dispose();
             }
         } catch (Exception e) {
             throw new RuntimeException("엑셀 파일 생성 중 오류 발생", e);

--- a/src/main/java/team/startup/expo/domain/excel/service/impl/StandardParticipantInfoToExcelServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/excel/service/impl/StandardParticipantInfoToExcelServiceImpl.java
@@ -5,7 +5,7 @@ import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFFont;
 import org.apache.poi.xssf.usermodel.XSSFColor;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
 import team.startup.expo.domain.participant.entity.StandardParticipant;
@@ -54,7 +54,8 @@ public class StandardParticipantInfoToExcelServiceImpl implements StandardPartic
 
     @Override
     public void execute(String expoId, HttpServletResponse res) throws JsonProcessingException {
-        try (Workbook workbook = new XSSFWorkbook()) {
+        try (SXSSFWorkbook workbook = new SXSSFWorkbook(500)) {
+            workbook.setCompressTempFiles(true);
             Expo expo = expoRepository.findById(expoId)
                     .orElseThrow(NotFoundExpoException::new);
 
@@ -193,6 +194,8 @@ public class StandardParticipantInfoToExcelServiceImpl implements StandardPartic
             try (ServletOutputStream outputStream = res.getOutputStream()) {
                 workbook.write(outputStream);
                 outputStream.flush();
+            } finally {
+                workbook.dispose();
             }
         } catch (Exception e) {
             throw new RuntimeException("엑셀 파일 생성 중 오류 발생: " + e.getMessage(), e);

--- a/src/main/java/team/startup/expo/domain/excel/service/impl/TraineeAttendanceToExcelServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/excel/service/impl/TraineeAttendanceToExcelServiceImpl.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFFont;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.springframework.stereotype.Service;
 import team.startup.expo.domain.excel.service.TraineeAttendanceToExcelService;
 import team.startup.expo.domain.expo.entity.Expo;
@@ -127,7 +127,7 @@ public class TraineeAttendanceToExcelServiceImpl implements TraineeAttendanceToE
         String traineeName = trainee.getName();
         String trainingId = trainee.getTrainingId();
         try {
-            String infoJson = trainee.getInformationJson(); // 여기서 jsonb 컬럼 사용
+            String infoJson = trainee.getInformationJson();
             if (infoJson != null && !infoJson.isBlank()) {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> parsed = OBJECT_MAPPER.readValue(infoJson, Map.class);
@@ -139,7 +139,8 @@ public class TraineeAttendanceToExcelServiceImpl implements TraineeAttendanceToE
         } catch (Exception e) {
         }
 
-        try (Workbook workbook = new XSSFWorkbook()) {
+        try (SXSSFWorkbook workbook = new SXSSFWorkbook(200)) {
+            workbook.setCompressTempFiles(true);
             Sheet sheet = workbook.createSheet("출석부");
             sheet.setDefaultColumnWidth(14);
 
@@ -382,11 +383,13 @@ public class TraineeAttendanceToExcelServiceImpl implements TraineeAttendanceToE
 
             String fileName = "Trainee_Attendance_" + trainee.getName();
             res.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-            res.setHeader("Content-Disposition", "attachment; filename=" + fileName + ".xlsx");
+            res.setHeader("Content-Disposition", "attachment; filename=\"" + fileName + ".xlsx\"");
 
             try (ServletOutputStream outputStream = res.getOutputStream()) {
                 workbook.write(outputStream);
                 outputStream.flush();
+            } finally {
+                workbook.dispose();
             }
         } catch (IOException e) {
             throw new RuntimeException("출석부 엑셀 생성 중 오류 발생", e);

--- a/src/main/java/team/startup/expo/domain/excel/service/impl/TraineeInfoToExcelServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/excel/service/impl/TraineeInfoToExcelServiceImpl.java
@@ -10,7 +10,7 @@ import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFColor;
 import org.apache.poi.xssf.usermodel.XSSFFont;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import team.startup.expo.domain.excel.service.TraineeInfoToExcelService;
 import team.startup.expo.domain.expo.entity.Expo;
 import team.startup.expo.domain.expo.exception.NotFoundExpoException;
@@ -70,7 +70,7 @@ public class TraineeInfoToExcelServiceImpl implements TraineeInfoToExcelService 
 
             Map<Long, List<TrainingProgramUser>> programUserMap = loadTrainingProgramUsersBatch(traineeIds);
 
-            Workbook workbook = createWorkbook(traineeList, dynamicDataMap, programUserMap);
+            SXSSFWorkbook workbook = createWorkbook(traineeList, dynamicDataMap, programUserMap);
 
             writeToResponse(res, workbook);
 
@@ -83,12 +83,13 @@ public class TraineeInfoToExcelServiceImpl implements TraineeInfoToExcelService 
         }
     }
 
-    private Workbook createWorkbook(
+    private SXSSFWorkbook createWorkbook(
             List<Trainee> traineeList,
             Map<Long, Map<String, String>> dynamicDataMap,
             Map<Long, List<TrainingProgramUser>> programUserMap
     ) {
-        Workbook workbook = new XSSFWorkbook();
+        SXSSFWorkbook workbook = new SXSSFWorkbook(500);
+        workbook.setCompressTempFiles(true);
         Sheet sheet = workbook.createSheet("사전 교원연수자 정보");
         sheet.setDefaultColumnWidth(DEFAULT_COLUMN_WIDTH);
 
@@ -261,16 +262,18 @@ public class TraineeInfoToExcelServiceImpl implements TraineeInfoToExcelService 
         style.setBorderRight(BorderStyle.THIN);
     }
 
-    private void writeToResponse(HttpServletResponse res, Workbook workbook) throws IOException {
+    private void writeToResponse(HttpServletResponse res, SXSSFWorkbook workbook) throws IOException {
         String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
         String fileName = "교원연수자_정보_" + timestamp;
 
         res.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        res.setHeader("Content-Disposition", "attachment; filename=" + fileName + ".xlsx");
+        res.setHeader("Content-Disposition", "attachment; filename=\"" + fileName + ".xlsx\"");
 
         try (ServletOutputStream outputStream = res.getOutputStream()) {
             workbook.write(outputStream);
+            outputStream.flush();
         } finally {
+            workbook.dispose();
             workbook.close();
         }
     }


### PR DESCRIPTION
## 💡 배경 및 개요

> 기존 Excel 다운로드가 XSSFWorkbook 기반이라 생성 과정에서 워크북 전체를 JVM 메모리에 올려서 메모리 급증에 위험이 있었습니다. 이를 SXSSFWorkbook 스트리밍 방식으로 전환하고 temp 파일 정리(dispose)를 추가해, 엑셀 생성 메모리 사용을 줄여 안정적으로 다운로드되도록 개선했습니다.

Resolves: #368 

## 📃 작업내용

> SXSSFWorkbook으로 변경

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타