### PR TITLE
fix :: 신청 서비스 Race Condition 수정 - 중복 신청 방지

### DIFF
--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForParticipantServiceImpl.java
@@ -31,7 +31,7 @@ public class FieldApplicationForParticipantServiceImpl implements FieldApplicati
     private final DateUtil dateUtil;
 
     public void execute(String expoId, ApplicationForParticipantRequestDto dto) {
-        Expo expo = expoRepository.findById(expoId)
+        Expo expo = expoRepository.findByIdWithLock(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
         if (!dateUtil.dateComparison(expo.getStartedDay(), expo.getFinishedDay()))

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationForTraineeServiceImpl.java
@@ -33,7 +33,7 @@ public class FieldApplicationForTraineeServiceImpl implements FieldApplicationFo
     private final DateUtil dateUtil;
 
     public void execute(String expoId, ApplicationForTraineeRequestDto dto) {
-        Expo expo = expoRepository.findById(expoId)
+        Expo expo = expoRepository.findByIdWithLock(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
         if (!dateUtil.dateComparison(expo.getStartedDay(), expo.getFinishedDay()))

--- a/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationTemporaryQrServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/FieldApplicationTemporaryQrServiceImpl.java
@@ -26,7 +26,7 @@ public class FieldApplicationTemporaryQrServiceImpl implements FieldApplicationT
     private final DateUtil dateUtil;
 
     public ApplicationTemporaryQrResponseDto execute(String expoId, ApplicationTemporaryQrRequestDto dto) {
-        Expo expo = expoRepository.findById(expoId)
+        Expo expo = expoRepository.findByIdWithLock(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
         if (!dateUtil.dateComparison(expo.getStartedDay(), expo.getFinishedDay()))

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForParticipantServiceImpl.java
@@ -37,7 +37,7 @@ public class PreApplicationForParticipantServiceImpl implements PreApplicationFo
     private final FormRepository formRepository;
 
     public void execute(String expoId, ApplicationForParticipantRequestDto dto) {
-        Expo expo = expoRepository.findById(expoId)
+        Expo expo = expoRepository.findByIdWithLock(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
         if (!dateUtil.dateComparison(expo.getStartedDay(), expo.getFinishedDay()))

--- a/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
+++ b/src/main/java/team/startup/expo/domain/application/service/impl/PreApplicationForTraineeServiceImpl.java
@@ -31,7 +31,7 @@ public class PreApplicationForTraineeServiceImpl implements PreApplicationForTra
     private final DateUtil dateUtil;
 
     public void execute(String expoId, ApplicationForTraineeRequestDto dto) {
-        Expo expo = expoRepository.findById(expoId)
+        Expo expo = expoRepository.findByIdWithLock(expoId)
                 .orElseThrow(NotFoundExpoException::new);
 
         if (!dateUtil.dateComparison(expo.getStartedDay(), expo.getFinishedDay()))

--- a/src/main/java/team/startup/expo/domain/expo/repository/ExpoRepository.java
+++ b/src/main/java/team/startup/expo/domain/expo/repository/ExpoRepository.java
@@ -1,7 +1,16 @@
 package team.startup.expo.domain.expo.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import team.startup.expo.domain.expo.entity.Expo;
 
+import java.util.Optional;
+
 public interface ExpoRepository extends JpaRepository<Expo, String> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Expo e WHERE e.id = :id")
+    Optional<Expo> findByIdWithLock(String id);
 }


### PR DESCRIPTION
close #375

## 문제

신청 서비스 4개(`Pre/FieldApplicationForParticipant`, `Pre/FieldApplicationForTrainee`)에서 동시 요청 시 중복 신청이 발생하는 Race Condition이 존재했습니다.

**취약 패턴 (Check-Then-Act without lock)**
```
Thread A: existsByPhoneNumber() → false  ─┐
Thread B: existsByPhoneNumber() → false  ─┤ 동시 통과
Thread A: saveParticipant() → INSERT      │
Thread B: saveParticipant() → INSERT     ─┘ 중복 INSERT 발생
```

`saveParticipant()` 내부의 `findByPhoneNumberAndExpoForWrite()`(PESSIMISTIC_WRITE)는 이미 존재하는 행에만 락을 걸 수 있어, **신규 삽입 구간의 경쟁 조건을 막지 못했습니다.**

## 해결

`ExpoRepository`에 `findByIdWithLock()`(`PESSIMISTIC_WRITE`) 추가 후, 모든 신청 서비스에서 Expo를 조회할 때 해당 메서드를 사용하도록 변경하였습니다.

Expo 행에 락을 선점함으로써 동일 엑스포로 들어오는 신청 트랜잭션이 직렬화되고, 이후 중복 체크 → INSERT 구간 전체가 원자적으로 보호됩니다.

**수정 후 흐름**
```
Thread A: SELECT ... FROM tb_expo WHERE id=? FOR UPDATE  → 락 획득
Thread B: SELECT ... FROM tb_expo WHERE id=? FOR UPDATE  → 대기
Thread A: existsBy...() → false → INSERT → COMMIT → 락 해제
Thread B: 락 획득 → existsBy...() → true → AlreadyApplicationUserException
```

## 변경 파일

- `ExpoRepository` — `findByIdWithLock()` 추가
- `FieldApplicationForParticipantServiceImpl` — `findByIdWithLock` 사용
- `PreApplicationForParticipantServiceImpl` — `findByIdWithLock` 사용
- `FieldApplicationForTraineeServiceImpl` — `findByIdWithLock` 사용
- `PreApplicationForTraineeServiceImpl` — `findByIdWithLock` 사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)